### PR TITLE
Add near comparision because browsers sometimes round complex layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Here's the command list:
  * [`compare-elements-css-false`](#compare-elements-css-false)
  * [`compare-elements-position`](#compare-elements-position)
  * [`compare-elements-position-false`](#compare-elements-position-false)
+ * [`compare-elements-position-near`](#compare-elements-position-near)
+ * [`compare-elements-position-near-false`](#compare-elements-position-near-false)
  * [`compare-elements-property`](#compare-elements-property)
  * [`compare-elements-property-false`](#compare-elements-property-false)
  * [`compare-elements-text`](#compare-elements-text)
@@ -557,7 +559,39 @@ compare-elements-position-false: ("//element1", "//element2", ("x", "y"))
 compare-elements-position-false: ("element1", "element2", ("y", "x"))
 ```
 
+#### compare-elements-position-near
+
+**compare-elements-position** command allows you to check that two DOM elements' CSS X/Y positions are **within 1px**. Examples:
+
+```
+// Compare the X position.
+compare-elements-position-near: ("//element1", "element2", ("x"))
+// Compare the Y position.
+compare-elements-position-near: ("element1", "//element2", ("y"))
+// Compare the X and Y positions.
+compare-elements-position-near: ("//element1", "//element2", ("x", "y"))
+// Compare the Y and X positions.
+compare-elements-position-near: ("element1", "element2", ("y", "x"))
+```
+
 Another thing to be noted: if you don't care wether the selector exists or not either, take a look at the [`fail`](#fail) command too.
+
+#### compare-elements-position-false
+
+**compare-elements-position-false** command allows you to check that two DOM elements' CSS X/Y positions differ by more than 1px. Examples:
+
+```
+// IMPORTANT: "element1" and "element2" have to exist otherwise the command will fail!
+
+// Compare the X position.
+compare-elements-position-near-false: ("//element1", "element2", ("x"))
+// Compare the Y position.
+compare-elements-position-near-false: ("element1", "//element2", ("y"))
+// Compare the X and Y positions.
+compare-elements-position-near-false: ("//element1", "//element2", ("x", "y"))
+// Compare the Y and X positions.
+compare-elements-position-near-false: ("element1", "element2", ("y", "x"))
+```
 
 #### compare-elements-property
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -1584,9 +1584,12 @@ function parseCompareElementsPositionInner(line, options, assertFalse, assertNea
         if (value === 'x') {
             if (!x) {
                 if (assertNear) {
+                    let delta_x = 1;
                     code += 'let x1 = e1.getBoundingClientRect().left;\n' +
                         'let x2 = e2.getBoundingClientRect().left;\n' +
-                        'if (Math.abs(x1 - x2) < 1) { throw "different X values: " + x1 + " != " + x2; }\n';
+                        'let delta = Math.abs(x1 - x2);\n' +
+                        'if (delta < ' + delty_x + ') {' +
+                        'throw "delta X values too large: " + x1 + " - " + x2 + " = " + delta; }\n';
                 } else {
                     code += 'let x1 = e1.getBoundingClientRect().left;\n' +
                         'let x2 = e2.getBoundingClientRect().left;\n' +
@@ -1597,9 +1600,12 @@ function parseCompareElementsPositionInner(line, options, assertFalse, assertNea
         } else if (value === 'y') {
             if (!y) {
                 if (assertNear) {
+                    let delta_y = 1;
                     code += 'let y1 = e1.getBoundingClientRect().top;\n' +
                         'let y2 = e2.getBoundingClientRect().top;\n' +
-                        'if (Math.abs(y1 - y2) < 1) { throw "different Y values: " + y1 + " != " + y2; }\n';
+                        'let delta = Math.abs(y1 - y2);\n' +
+                        'if (delta < ' + delta_y + ') {' +
+                        'throw "delta Y values too large: " + y1 + " - " + y2 + " = " + delta; }\n';
                 } else {
                     code += 'let y1 = e1.getBoundingClientRect().top;\n' +
                         'let y2 = e2.getBoundingClientRect().top;\n' +
@@ -2184,6 +2190,8 @@ const ORDERS = {
     'compare-elements-css-false': parseCompareElementsCssFalse,
     'compare-elements-position': parseCompareElementsPosition,
     'compare-elements-position-false': parseCompareElementsPositionFalse,
+    'compare-elements-position-near': parseCompareElementsPositionNear,
+    'compare-elements-position-near-false': parseCompareElementsPositionNearFalse,
     'compare-elements-property': parseCompareElementsProperty,
     'compare-elements-property-false': parseCompareElementsPropertyFalse,
     'compare-elements-text': parseCompareElementsText,

--- a/src/commands.js
+++ b/src/commands.js
@@ -1521,7 +1521,7 @@ function parseCompareElementsPropertyFalse(line, options) {
     return parseCompareElementsPropertyInner(line, options, true);
 }
 
-function parseCompareElementsPositionInner(line, options, assertFalse) {
+function parseCompareElementsPositionInner(line, options, assertFalse, assertNear) {
     const p = new Parser(line, options.variables);
     p.parse();
     if (p.error !== null) {
@@ -1583,16 +1583,28 @@ function parseCompareElementsPositionInner(line, options, assertFalse) {
         const value = sub_tuple[i].getRaw();
         if (value === 'x') {
             if (!x) {
-                code += 'let x1 = e1.getBoundingClientRect().left;\n' +
-                    'let x2 = e2.getBoundingClientRect().left;\n' +
-                    'if (x1 !== x2) { throw "different X values: " + x1 + " != " + x2; }\n';
+                if (assertNear) {
+                    code += 'let x1 = e1.getBoundingClientRect().left;\n' +
+                        'let x2 = e2.getBoundingClientRect().left;\n' +
+                        'if (Math.abs(x1 - x2) < 1) { throw "different X values: " + x1 + " != " + x2; }\n';
+                } else {
+                    code += 'let x1 = e1.getBoundingClientRect().left;\n' +
+                        'let x2 = e2.getBoundingClientRect().left;\n' +
+                        'if (x1 !== x2) { throw "different X values: " + x1 + " != " + x2; }\n';
+                }
             }
             x = true;
         } else if (value === 'y') {
             if (!y) {
-                code += 'let y1 = e1.getBoundingClientRect().top;\n' +
-                    'let y2 = e2.getBoundingClientRect().top;\n' +
-                    'if (y1 !== y2) { throw "different Y values: " + y1 + " != " + y2; }\n';
+                if (assertNear) {
+                    code += 'let y1 = e1.getBoundingClientRect().top;\n' +
+                        'let y2 = e2.getBoundingClientRect().top;\n' +
+                        'if (Math.abs(y1 - y2) < 1) { throw "different Y values: " + y1 + " != " + y2; }\n';
+                } else {
+                    code += 'let y1 = e1.getBoundingClientRect().top;\n' +
+                        'let y2 = e2.getBoundingClientRect().top;\n' +
+                        'if (y1 !== y2) { throw "different Y values: " + y1 + " != " + y2; }\n';
+                }
             }
             y = true;
         } else {
@@ -1617,14 +1629,28 @@ function parseCompareElementsPositionInner(line, options, assertFalse) {
 //
 // * ("CSS selector 1" | "XPath 1", "CSS selector 2" | "XPath 2", ("x"|"y"))
 function parseCompareElementsPosition(line, options) {
-    return parseCompareElementsPositionInner(line, options, false);
+    return parseCompareElementsPositionInner(line, options, false, false);
 }
 
 // Possible inputs:
 //
 // * ("CSS selector 1" | "XPath 1", "CSS selector 2" | "XPath 2", ("x"|"y"))
 function parseCompareElementsPositionFalse(line, options) {
-    return parseCompareElementsPositionInner(line, options, true);
+    return parseCompareElementsPositionInner(line, options, true, false);
+}
+
+// Possible inputs:
+//
+// * ("CSS selector 1" | "XPath 1", "CSS selector 2" | "XPath 2", ["CSS properties"])
+function parseCompareElementsPositionNear(line, options) {
+    return parseCompareElementsPropertyInner(line, options, false, true);
+}
+
+// Possible inputs:
+//
+// * ("CSS selector 1" | "XPath 1", "CSS selector 2" | "XPath 2", ["CSS properties"])
+function parseCompareElementsPositionNearFalse(line, options) {
+    return parseCompareElementsPropertyInner(line, options, true, true);
 }
 
 // Possible inputs:

--- a/tests/scripts/position-nearness.goml
+++ b/tests/scripts/position-nearness.goml
@@ -1,0 +1,3 @@
+screenshot: false
+goto: file://|CURRENT_DIR|/|DOC_PATH|/elements.html
+compare-elements-position-near-false: (".content>.right>div", ".content>.right>div", {"x": 1, "y": 1))


### PR DESCRIPTION
While working on https://github.com/rust-lang/rust/pull/86594 I noticed that borders sometime lead to rounding issues with the absolute comparison.
So I added this command to ensure the difference is below `1px`

Cheers,
Stefan