### PR TITLE
Fix failing tests handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -259,7 +259,7 @@ async function runCommand(loaded, logs, options, browser) {
                 error_log += `(line ${line_number}) command \`${command['original']}\` was ` +
                     'supposed to fail but succeeded\n';
             }
-            if (error_log.length > 0) {
+            if (failed === true) {
                 if (command['fatal_error'] === true || extras.pauseOnError === true) {
                     break;
                 }

--- a/tests/ui-tests/assert-text.goml
+++ b/tests/ui-tests/assert-text.goml
@@ -5,6 +5,8 @@ goto: file://|CURRENT_DIR|/|DOC_PATH|/elements.html
 // This test ensures it fails because "header" doesn't end with  "Another" but starts with it.
 assert-text-false: ("header", "Another", [ENDS_WITH, STARTS_WITH])
 assert-text-false: ("header", "Another", STARTS_WITH)
+// Checks that if a command failed before this one, it'll still continue
+click: "header"
 // The opposite of the previous check.
 assert-text: ("header", "Another", [STARTS_WITH, ENDS_WITH])
 assert-text: ("header", "Another", ENDS_WITH)
@@ -12,4 +14,7 @@ assert-text: ("header", "Another", ENDS_WITH)
 assert-document-property-false: ({"title": "Other"}, [ENDS_WITH, STARTS_WITH])
 assert-document-property-false: ({"title": "Other"}, STARTS_WITH)
 assert-document-property: ({"title": "Other"}, [STARTS_WITH, ENDS_WITH])
+assert-document-property: ({"title": "Other"}, ENDS_WITH)
+// Ensures that a "fatal error" stops the script as expected.
+click: "#non-existent"
 assert-document-property: ({"title": "Other"}, ENDS_WITH)

--- a/tests/ui-tests/assert-text.output
+++ b/tests/ui-tests/assert-text.output
@@ -3,12 +3,13 @@
 assert-text... FAILED
 [ERROR] (line 6) Error: Evaluation failed: assert didn't fail (for STARTS_WITH check): for command `assert-text-false: ("header", "Another", [ENDS_WITH, STARTS_WITH])`
 [ERROR] (line 7) Error: Evaluation failed: assert didn't fail (for STARTS_WITH check): for command `assert-text-false: ("header", "Another", STARTS_WITH)`
-[ERROR] (line 9) Error: Evaluation failed: "Another page!" doesn't end with "Another": for command `assert-text: ("header", "Another", [STARTS_WITH, ENDS_WITH])`
-[ERROR] (line 10) Error: Evaluation failed: "Another page!" doesn't end with "Another": for command `assert-text: ("header", "Another", ENDS_WITH)`
-[ERROR] (line 12) Error: Evaluation failed: assert didn't fail: for command `assert-document-property-false: ({"title": "Other"}, [ENDS_WITH, STARTS_WITH])`
-[ERROR] (line 13) Error: Evaluation failed: assert didn't fail: for command `assert-document-property-false: ({"title": "Other"}, STARTS_WITH)`
-[ERROR] (line 14) Error: Evaluation failed: Property `title` (`Other page`) does not end with `Other`: for command `assert-document-property: ({"title": "Other"}, [STARTS_WITH, ENDS_WITH])`
-[ERROR] (line 15) Error: Evaluation failed: Property `title` (`Other page`) does not end with `Other`: for command `assert-document-property: ({"title": "Other"}, ENDS_WITH)`
+[ERROR] (line 11) Error: Evaluation failed: "Another page!" doesn't end with "Another": for command `assert-text: ("header", "Another", [STARTS_WITH, ENDS_WITH])`
+[ERROR] (line 12) Error: Evaluation failed: "Another page!" doesn't end with "Another": for command `assert-text: ("header", "Another", ENDS_WITH)`
+[ERROR] (line 14) Error: Evaluation failed: assert didn't fail: for command `assert-document-property-false: ({"title": "Other"}, [ENDS_WITH, STARTS_WITH])`
+[ERROR] (line 15) Error: Evaluation failed: assert didn't fail: for command `assert-document-property-false: ({"title": "Other"}, STARTS_WITH)`
+[ERROR] (line 16) Error: Evaluation failed: Property `title` (`Other page`) does not end with `Other`: for command `assert-document-property: ({"title": "Other"}, [STARTS_WITH, ENDS_WITH])`
+[ERROR] (line 17) Error: Evaluation failed: Property `title` (`Other page`) does not end with `Other`: for command `assert-document-property: ({"title": "Other"}, ENDS_WITH)`
+[ERROR] (line 19) "#non-existent" not found: for command `click: "#non-existent"`
 
 
 <= doc-ui tests done: 0 succeeded, 1 failed


### PR DESCRIPTION
An example of this case:

```
assert: "#something-which-does-not-exist
click: "#valid-id"
assert: "#another-check"
```

In this case, it should run all 3 commands but it was stopping at the first fatal error command (`click` in this case) because the `assert` before it failed.