### PR TITLE
Parse commands one by one instead of all at once to make variables useable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -220,7 +220,7 @@ async function runAllCommands(loaded, logs, options, browser) {
             const command = context_parser.get_next_command();
             if (command === null) {
                 if (nb_commands === 0) {
-                    logs.append('FAILED');
+                    logs.append('FAILED', true);
                     logs.append('=> No command to execute');
                     return Status.Failure;
                 }
@@ -230,7 +230,7 @@ async function runAllCommands(loaded, logs, options, browser) {
                 warnings.push.apply(warnings, command['warnings']);
             }
             if (Object.prototype.hasOwnProperty.call(command, 'error')) {
-                logs.append('FAILED');
+                logs.append('FAILED', true);
                 logs.warn(warnings);
                 logs.append(`[ERROR] line ${command['line']}: ${command['error']}`);
                 return Status.Failure;

--- a/src/parser.js
+++ b/src/parser.js
@@ -265,7 +265,11 @@ class Parser {
         if (typeof variables === 'undefined' || variables === null) {
             variables = {};
         }
-        this.variables = variables;
+        this.variables = Object.create(null);
+        // We don't copy the map, only its content.
+        for (const key in variables) {
+            this.variables[key] = variables[key];
+        }
         // For humans, the first line isn't 0 but 1.
         this.currentLine = 1;
         this.command = null;


### PR DESCRIPTION
Part of #351.