### PR TITLE
Add test case for named arguments with extra arguments

### DIFF
--- a/tests/ui-tests/function-named-map-extra-argument.goml
+++ b/tests/ui-tests/function-named-map-extra-argument.goml
@@ -1,0 +1,13 @@
+// This test ensures that the `define-function` and `call-function` produces an error when an extra, unexpected argument is supplied.
+goto: "file://" + |CURRENT_DIR| + "/" + |DOC_PATH| + "/elements.html"
+
+define-function: (
+    "fn1",
+    (background_color, whole_check),
+    [
+        ("assert-css", ("header", {"background-color": |background_color|})),
+        ("assert-css", ("header", |whole_check|)),
+    ],
+)
+// Error because there is an extra argument.
+call-function: ("fn1", {"background_color": "a", "whole_check": {"color": "a"}, "k": {"color": "a"}})

--- a/tests/ui-tests/function-named-map-extra-argument.output
+++ b/tests/ui-tests/function-named-map-extra-argument.output
@@ -1,0 +1,6 @@
+=> Starting doc-ui tests...
+
+function-named-map-extra-argument... FAILED
+[ERROR] line 13: function `fn1` expected 2 arguments, found 3 (from command `("fn1", {"background_color": "a", "whole_check": {"color": "a"}, "k": {"color": "a"}})`)
+
+<= doc-ui tests done: 0 succeeded, 1 failed


### PR DESCRIPTION
This is written as a separate test case, instead of part of `functions.goml`, because the mismatched argument count is a fatal error. If I added it to the end of the existing file, it did not actually run.