### PR TITLE
Allow to use tuples, arrays and JSON dicts in expressions for equality checks

### DIFF
--- a/goml-script.md
+++ b/goml-script.md
@@ -89,6 +89,15 @@ true != false // ok
 1 == "1" // ok
 ```
 
+You can also compare arrays, tuples and JSON dictionaries:
+
+```
+["a", "b"] == [1, 2] // computed as false
+["a", "b"] != [1, 2] // computed as true
+(1, "a") == (1, "a", "e") // computed as false
+{"1": "a"} != {"1": "e"} // computed as true
+```
+
 ## Command list
 
 Those scripts aim to be as quick to write and as small as possible. To do so, they provide a short list of commands. Please note that those scripts must **always** start with a [`goto`](#goto) command (non-interactional commands such as `screenshot-comparison` or `expect-failure` can be use first as well).

--- a/src/commands/assert.js
+++ b/src/commands/assert.js
@@ -1135,6 +1135,31 @@ found \`${parser.getRawArgs()}\` (${parser.getArticleKind()})`};
     if (tuple[0].kind === 'boolean') {
         return {
             'instructions': [`\
+function compareArrayLike(t1, t2) {
+    if (t1.length !== t2.length) {
+        return false;
+    }
+    for ([index, value] of t1.entries()) {
+        if (value !== t2[index]) {
+            return false;
+        }
+    }
+    return true;
+}
+function compareJson(j1, j2) {
+    for (const key of Object.keys(j1)) {
+        if (j2[key] !== j1[key]) {
+            return false;
+        }
+    }
+    for (const key of Object.keys(j2)) {
+        if (j2[key] !== j1[key]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 const check = ${tuple[0].value};
 ${insertBefore}if (!check) {
     throw "Condition \`${cleanString(tuple[0].getErrorText())}\` was evaluated as false";

--- a/tests/test-js/api-output/parseAssert/bool-1.toml
+++ b/tests/test-js/api-output/parseAssert/bool-1.toml
@@ -1,5 +1,30 @@
 instructions = [
-  """const check = 1 > 2 + 3;
+  """function compareArrayLike(t1, t2) {
+    if (t1.length !== t2.length) {
+        return false;
+    }
+    for ([index, value] of t1.entries()) {
+        if (value !== t2[index]) {
+            return false;
+        }
+    }
+    return true;
+}
+function compareJson(j1, j2) {
+    for (const key of Object.keys(j1)) {
+        if (j2[key] !== j1[key]) {
+            return false;
+        }
+    }
+    for (const key of Object.keys(j2)) {
+        if (j2[key] !== j1[key]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+const check = 1 > 2 + 3;
 if (!check) {
     throw \"Condition `1 > 2 + 3` was evaluated as false\";
 }""",

--- a/tests/test-js/api-output/parseAssert/bool-2.toml
+++ b/tests/test-js/api-output/parseAssert/bool-2.toml
@@ -1,5 +1,30 @@
 instructions = [
-  """const check = 1 >= 2 / (3 + 6);
+  """function compareArrayLike(t1, t2) {
+    if (t1.length !== t2.length) {
+        return false;
+    }
+    for ([index, value] of t1.entries()) {
+        if (value !== t2[index]) {
+            return false;
+        }
+    }
+    return true;
+}
+function compareJson(j1, j2) {
+    for (const key of Object.keys(j1)) {
+        if (j2[key] !== j1[key]) {
+            return false;
+        }
+    }
+    for (const key of Object.keys(j2)) {
+        if (j2[key] !== j1[key]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+const check = 1 >= 2 / (3 + 6);
 if (!check) {
     throw \"Condition `1 >= 2 / (3 + 6)` was evaluated as false\";
 }""",

--- a/tests/test-js/api-output/parseAssert/bool-3.toml
+++ b/tests/test-js/api-output/parseAssert/bool-3.toml
@@ -24,12 +24,10 @@ function compareJson(j1, j2) {
     return true;
 }
 
-const check = 1 > 2 + 3;
-try {
+const check = compareJson({\"a\": 1}, {\"a\": 2});
 if (!check) {
-    throw \"Condition `1 > 2 + 3` was evaluated as false\";
-}
-} catch(e) { return; } throw \"assert didn't fail\";""",
+    throw \"Condition `{\\\"a\\\": 1} == {\\\"a\\\": 2}` was evaluated as false\";
+}""",
 ]
 wait = false
 checkResult = true

--- a/tests/test-js/api-output/parseAssert/bool-4.toml
+++ b/tests/test-js/api-output/parseAssert/bool-4.toml
@@ -24,12 +24,10 @@ function compareJson(j1, j2) {
     return true;
 }
 
-const check = 1 > 2 + 3;
-try {
+const check = !compareJson({\"a\": 1}, {\"a\": 2});
 if (!check) {
-    throw \"Condition `1 > 2 + 3` was evaluated as false\";
-}
-} catch(e) { return; } throw \"assert didn't fail\";""",
+    throw \"Condition `{\\\"a\\\": 1} != {\\\"a\\\": 2}` was evaluated as false\";
+}""",
 ]
 wait = false
 checkResult = true

--- a/tests/test-js/api-output/parseAssert/bool-5.toml
+++ b/tests/test-js/api-output/parseAssert/bool-5.toml
@@ -24,12 +24,10 @@ function compareJson(j1, j2) {
     return true;
 }
 
-const check = 1 > 2 + 3;
-try {
+const check = compareArrayLike([\"a\", \"b\"], [\"a\", \"c\"]);
 if (!check) {
-    throw \"Condition `1 > 2 + 3` was evaluated as false\";
-}
-} catch(e) { return; } throw \"assert didn't fail\";""",
+    throw \"Condition `[\\\"a\\\", \\\"b\\\"] == [\\\"a\\\", \\\"c\\\"]` was evaluated as false\";
+}""",
 ]
 wait = false
 checkResult = true

--- a/tests/test-js/api-output/parseAssert/bool-6.toml
+++ b/tests/test-js/api-output/parseAssert/bool-6.toml
@@ -24,12 +24,10 @@ function compareJson(j1, j2) {
     return true;
 }
 
-const check = 1 > 2 + 3;
-try {
+const check = !compareArrayLike([\"a\", \"b\"], [\"a\", \"c\"]);
 if (!check) {
-    throw \"Condition `1 > 2 + 3` was evaluated as false\";
-}
-} catch(e) { return; } throw \"assert didn't fail\";""",
+    throw \"Condition `[\\\"a\\\", \\\"b\\\"] != [\\\"a\\\", \\\"c\\\"]` was evaluated as false\";
+}""",
 ]
 wait = false
 checkResult = true

--- a/tests/test-js/api-output/parseAssert/bool-7.toml
+++ b/tests/test-js/api-output/parseAssert/bool-7.toml
@@ -24,12 +24,10 @@ function compareJson(j1, j2) {
     return true;
 }
 
-const check = 1 > 2 + 3;
-try {
+const check = compareArrayLike([\"a\", 1], [\"a\", 2]);
 if (!check) {
-    throw \"Condition `1 > 2 + 3` was evaluated as false\";
-}
-} catch(e) { return; } throw \"assert didn't fail\";""",
+    throw \"Condition `(\\\"a\\\", 1) == (\\\"a\\\", 2)` was evaluated as false\";
+}""",
 ]
 wait = false
 checkResult = true

--- a/tests/test-js/api-output/parseAssert/bool-8.toml
+++ b/tests/test-js/api-output/parseAssert/bool-8.toml
@@ -24,12 +24,10 @@ function compareJson(j1, j2) {
     return true;
 }
 
-const check = 1 > 2 + 3;
-try {
+const check = !compareArrayLike([\"a\", 1], [\"a\", 2]);
 if (!check) {
-    throw \"Condition `1 > 2 + 3` was evaluated as false\";
-}
-} catch(e) { return; } throw \"assert didn't fail\";""",
+    throw \"Condition `(\\\"a\\\", 1) != (\\\"a\\\", 2)` was evaluated as false\";
+}""",
 ]
 wait = false
 checkResult = true

--- a/tests/test-js/api-output/parseAssertFalse/bool-2.toml
+++ b/tests/test-js/api-output/parseAssertFalse/bool-2.toml
@@ -1,5 +1,30 @@
 instructions = [
-  """const check = 1 >= 2 / (3 + 6);
+  """function compareArrayLike(t1, t2) {
+    if (t1.length !== t2.length) {
+        return false;
+    }
+    for ([index, value] of t1.entries()) {
+        if (value !== t2[index]) {
+            return false;
+        }
+    }
+    return true;
+}
+function compareJson(j1, j2) {
+    for (const key of Object.keys(j1)) {
+        if (j2[key] !== j1[key]) {
+            return false;
+        }
+    }
+    for (const key of Object.keys(j2)) {
+        if (j2[key] !== j1[key]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+const check = 1 >= 2 / (3 + 6);
 try {
 if (!check) {
     throw \"Condition `1 >= 2 / (3 + 6)` was evaluated as false\";

--- a/tests/test-js/api-output/parseAssertFalse/bool-3.toml
+++ b/tests/test-js/api-output/parseAssertFalse/bool-3.toml
@@ -24,10 +24,10 @@ function compareJson(j1, j2) {
     return true;
 }
 
-const check = 1 > 2 + 3;
+const check = compareJson({\"a\": 1}, {\"a\": 2});
 try {
 if (!check) {
-    throw \"Condition `1 > 2 + 3` was evaluated as false\";
+    throw \"Condition `{\\\"a\\\": 1} == {\\\"a\\\": 2}` was evaluated as false\";
 }
 } catch(e) { return; } throw \"assert didn't fail\";""",
 ]

--- a/tests/test-js/api-output/parseAssertFalse/bool-4.toml
+++ b/tests/test-js/api-output/parseAssertFalse/bool-4.toml
@@ -24,10 +24,10 @@ function compareJson(j1, j2) {
     return true;
 }
 
-const check = 1 > 2 + 3;
+const check = !compareJson({\"a\": 1}, {\"a\": 2});
 try {
 if (!check) {
-    throw \"Condition `1 > 2 + 3` was evaluated as false\";
+    throw \"Condition `{\\\"a\\\": 1} != {\\\"a\\\": 2}` was evaluated as false\";
 }
 } catch(e) { return; } throw \"assert didn't fail\";""",
 ]

--- a/tests/test-js/api-output/parseAssertFalse/bool-5.toml
+++ b/tests/test-js/api-output/parseAssertFalse/bool-5.toml
@@ -24,10 +24,10 @@ function compareJson(j1, j2) {
     return true;
 }
 
-const check = 1 > 2 + 3;
+const check = compareArrayLike([\"a\", \"b\"], [\"a\", \"c\"]);
 try {
 if (!check) {
-    throw \"Condition `1 > 2 + 3` was evaluated as false\";
+    throw \"Condition `[\\\"a\\\", \\\"b\\\"] == [\\\"a\\\", \\\"c\\\"]` was evaluated as false\";
 }
 } catch(e) { return; } throw \"assert didn't fail\";""",
 ]

--- a/tests/test-js/api-output/parseAssertFalse/bool-6.toml
+++ b/tests/test-js/api-output/parseAssertFalse/bool-6.toml
@@ -24,10 +24,10 @@ function compareJson(j1, j2) {
     return true;
 }
 
-const check = 1 > 2 + 3;
+const check = !compareArrayLike([\"a\", \"b\"], [\"a\", \"c\"]);
 try {
 if (!check) {
-    throw \"Condition `1 > 2 + 3` was evaluated as false\";
+    throw \"Condition `[\\\"a\\\", \\\"b\\\"] != [\\\"a\\\", \\\"c\\\"]` was evaluated as false\";
 }
 } catch(e) { return; } throw \"assert didn't fail\";""",
 ]

--- a/tests/test-js/api-output/parseAssertFalse/bool-7.toml
+++ b/tests/test-js/api-output/parseAssertFalse/bool-7.toml
@@ -24,10 +24,10 @@ function compareJson(j1, j2) {
     return true;
 }
 
-const check = 1 > 2 + 3;
+const check = compareArrayLike([\"a\", 1], [\"a\", 2]);
 try {
 if (!check) {
-    throw \"Condition `1 > 2 + 3` was evaluated as false\";
+    throw \"Condition `(\\\"a\\\", 1) == (\\\"a\\\", 2)` was evaluated as false\";
 }
 } catch(e) { return; } throw \"assert didn't fail\";""",
 ]

--- a/tests/test-js/api-output/parseAssertFalse/bool-8.toml
+++ b/tests/test-js/api-output/parseAssertFalse/bool-8.toml
@@ -24,10 +24,10 @@ function compareJson(j1, j2) {
     return true;
 }
 
-const check = 1 > 2 + 3;
+const check = !compareArrayLike([\"a\", 1], [\"a\", 2]);
 try {
 if (!check) {
-    throw \"Condition `1 > 2 + 3` was evaluated as false\";
+    throw \"Condition `(\\\"a\\\", 1) != (\\\"a\\\", 2)` was evaluated as false\";
 }
 } catch(e) { return; } throw \"assert didn't fail\";""",
 ]

--- a/tests/test-js/api.js
+++ b/tests/test-js/api.js
@@ -145,6 +145,12 @@ function checkAssert(x, func) {
     // bool
     func('1 > 2 + 3', 'bool-1');
     func('1 >= 2 / (3 + 6)', 'bool-2');
+    func('{"a": 1} == {"a": 2}', 'bool-3');
+    func('{"a": 1} != {"a": 2}', 'bool-4');
+    func('["a", "b"] == ["a", "c"]', 'bool-5');
+    func('["a", "b"] != ["a", "c"]', 'bool-6');
+    func('("a", 1) == ("a", 2)', 'bool-7');
+    func('("a", 1) != ("a", 2)', 'bool-8');
 }
 
 function checkAssertAttribute(x, func) {

--- a/tests/ui-tests/assert-expr.goml
+++ b/tests/ui-tests/assert-expr.goml
@@ -7,6 +7,11 @@ assert-false: |var| > 2
 store-value: (var2, "a")
 assert: |var2| == "a"
 assert-false: |var2| != "a"
+store-value: (var3, {"a": 2})
+assert: {"a": 2} == |var3|
+assert-false: {"a": 2} != |var3|
+assert: (1, "a") == (1, "a")
+assert: [1, 2] == [1, 2]
 
 // Checking order of operations.
 store-value: (var, (1 + 2) * 4 + 1)
@@ -17,3 +22,6 @@ assert: |var| != 12 && 1 < 2
 assert: |var| != 13
 assert-false: |var| == 13
 assert: |var2| == |var|
+assert: {"b": 3} == |var3|
+assert: (1, "a") == (2, 3)
+assert: [1, 2] == ["a", "b"]

--- a/tests/ui-tests/assert-expr.output
+++ b/tests/ui-tests/assert-expr.output
@@ -1,9 +1,12 @@
 => Starting doc-ui tests...
 
 assert-expr... FAILED
-[ERROR] (line 17) Condition `|var| != 13` was evaluated as false: for command `assert: |var| != 13`
-[ERROR] (line 18) assert didn't fail: for command `assert-false: |var| == 13`
-[ERROR] (line 19) Condition `|var2| == |var|` was evaluated as false: for command `assert: |var2| == |var|`
+[ERROR] (line 22) Condition `|var| != 13` was evaluated as false: for command `assert: |var| != 13`
+[ERROR] (line 23) assert didn't fail: for command `assert-false: |var| == 13`
+[ERROR] (line 24) Condition `|var2| == |var|` was evaluated as false: for command `assert: |var2| == |var|`
+[ERROR] (line 25) Condition `{"b": 3} == |var3|` was evaluated as false: for command `assert: {"b": 3} == |var3|`
+[ERROR] (line 26) Condition `(1, "a") == (2, 3)` was evaluated as false: for command `assert: (1, "a") == (2, 3)`
+[ERROR] (line 27) Condition `[1, 2] == ["a", "b"]` was evaluated as false: for command `assert: [1, 2] == ["a", "b"]`
 
 
 <= doc-ui tests done: 0 succeeded, 1 failed


### PR DESCRIPTION
Fixes #464.

Follow-up of #463.