### PR TITLE
Add UI tests to ensure that `show-text: true` is not needed for borders

### DIFF
--- a/tests/ui-tests/assert-css-color.goml
+++ b/tests/ui-tests/assert-css-color.goml
@@ -1,3 +1,9 @@
 // This test is to ensure that if "show-text" is false, then it fails.
 go-to: "file://" + |CURRENT_DIR| + "/" + |DOC_PATH| + "/elements.html"
+// This test should succeed.
+assert-css: ("#js-create-elem", {
+    "border": "1px solid rgb(1, 1, 1)",
+    "border-color": "rgb(1, 1, 1)"}
+)
+// This test should fail.
 assert-css: (".content>.right>p", {"color": "rgb(0, 0, 0)"})

--- a/tests/ui-tests/assert-css-color.output
+++ b/tests/ui-tests/assert-css-color.output
@@ -1,7 +1,7 @@
 => Starting doc-ui tests...
 
 assert-css-color... FAILED
-[ERROR] (line 3): `show-text: true` needs to be used before checking for `color` (otherwise the browser doesn't compute it)
+[ERROR] (line 9): `show-text: true` needs to be used before checking for `color` (otherwise the browser doesn't compute it)
 
 
 <= doc-ui tests done: 0 succeeded, 1 failed


### PR DESCRIPTION
Fixes #318.