### PR TITLE
Fix hex conversion with alpha

### DIFF
--- a/src/css_parser.js
+++ b/src/css_parser.js
@@ -132,7 +132,8 @@ class CssParser {
                 continue;
             }
             if (otherElem.colorKind.startsWith('hex')) {
-                const alpha = otherElem.hasAlpha || elem.color[3] < 1 ? elem.color[3] * 255 : null;
+                const alpha = otherElem.hasAlpha || elem.color[3] < 1 ?
+                    Math.round(elem.color[3] * 255) : null;
                 const values = elem.color.slice(0, 3).map(v => toHex(v));
                 if (alpha !== null) {
                     values.push(toHex(alpha));

--- a/tests/test-js/parser.js
+++ b/tests/test-js/parser.js
@@ -129,6 +129,10 @@ function checkCssParser(x) {
     p = new CssParser('#aaa3 #aaa');
     p2 = new CssParser('rgb(224, 224, 224) rgb(224, 224, 224)');
     x.assert(p2.sameFormatAs(p), '#e0e0e0ff #e0e0e0');
+
+    p = new CssParser('rgba(255, 236, 164, 0.06)');
+    p2 = new CssParser('#aaa');
+    x.assert(p.sameFormatAs(p2), '#ffeca40f');
 }
 
 function checkTuple(x) {


### PR DESCRIPTION
Funny case where `rgba(255, 236, 164, 0.06)` was converted into `#ffeca4f.4ccccccccccc8`. A rounding was missing.