### PR TITLE
Add support object paths in assert-window-property* and `assert-document-property*` commands

### DIFF
--- a/goml-script.md
+++ b/goml-script.md
@@ -421,6 +421,9 @@ Another thing to be noted: if you don't care whether the selector exists or not 
 assert-document-property: ({"URL": "https://some.where", "title": "a title"})
 // If you only provide properties, you can also only provide a JSON dict:
 assert-document-property: {"URL": "https://some.where", "title": "a title"}
+
+// To access a child element, you can use object paths:
+assert-document-property: { "body"."firstChildElement"."clientTop": "10px" }
 ```
 
 If you want to check that a property doesn't exist, you can use `null`:
@@ -450,6 +453,9 @@ assert-document-property: ({"URL": "https://some.where", "title": "a title"}, [S
 assert-document-property-false: ({"URL": "https://some.where", "title": "a title"})
 // If you only provide properties, you can also only provide a JSON dict:
 assert-document-property-false: {"URL": "https://some.where", "title": "a title"}
+
+// To access a child element, you can use object paths:
+assert-document-property-false: { "body"."firstChildElement"."clientTop": "10px" }
 ```
 
 If you want to check that a property does exist, you can use `null`:
@@ -787,6 +793,9 @@ For more information about variables, read the [variables section](#variables).
 assert-window-property: ({"pageYOffset": "0", "location": "https://some.where"})
 // If you only provide properties, you can also only provide a JSON dict:
 assert-window-property: {"pageYOffset": "0", "location": "https://some.where"}
+
+// To access a child element, you can use object paths:
+assert-document-property: { "document"."body"."firstChildElement"."clientTop": "10px" }
 ```
 
 If you want to check that a property doesn't exist, you can use `null`:
@@ -822,6 +831,9 @@ assert-window-property: (
 assert-window-property-false: ({"location": "https://some.where", "pageYOffset": "10"})
 // If you only provide properties, you can also only provide a JSON dict:
 assert-window-property-false: {"location": "https://some.where", "pageYOffset": "10"}
+
+// To access a child element, you can use object paths:
+assert-document-property-false: { "document"."body"."firstChildElement"."clientTop": "10px" }
 ```
 
 If you want to check that a property does exist, you can use `null`:
@@ -843,7 +855,7 @@ assert-window-property-false: (
 You can even combine the checks:
 
 ```
-assert-windo-property-false: (
+assert-window-property-false: (
     {"location": "https://some.where", "pageYOffset": "10"},
     [STARTS_WITH, ENDS_WITH],
 )

--- a/src/commands/assert.js
+++ b/src/commands/assert.js
@@ -493,10 +493,9 @@ the check will be performed on the element itself`);
     let unexpectedPropError = '';
     let unknown = '';
     if (!assertFalse) {
-        unknown = `\
+        unknown = `
 const p = ${varKey}.map(p => \`"\${p}"\`).join('.');
-nonMatchingProps.push('Unknown property \`' + p + '\`');
-`;
+nonMatchingProps.push('Unknown property \`' + p + '\`');`;
         unexpectedPropError = `\
 const p = prop.map(p => \`"\${p}"\`).join('.');
 nonMatchingProps.push("Expected property \`" + p + "\` to not exist, found: \`" + val + "\`");`;
@@ -524,10 +523,8 @@ ${indentString(generateCheckObjectPaths(), 1)}
             if (val !== undefined && val !== null) {
 ${indentString(unexpectedPropError, 4)}
                 return;
-            }
-${indentString(expectedPropError, 3)}
-        }, prop => {
-${indentString(expectedPropError, 3)}
+            }${indentString(expectedPropError, 3)}
+        }, prop => {${indentString(expectedPropError, 3)}
         });
     }
     for (const [${varKey}, ${varValue}] of ${varDict}) {
@@ -537,8 +534,8 @@ ${indentString(expectedPropError, 3)}
             }
             const prop = String(val);
 ${indentString(checks.join('\n'), 3)}
-        }, ${varKey} => {
-${indentString(unknown, 3)}});
+        }, ${varKey} => {${indentString(unknown, 3)}
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join("; ");

--- a/src/commands/assert.js
+++ b/src/commands/assert.js
@@ -18,6 +18,23 @@ const { validator } = require('../validator.js');
 // Not the same `utils.js`!
 const { hasError } = require('../utils.js');
 
+function generateCheckObjectPaths() {
+    return `\
+function checkObjectPaths(object, path, callback, notFoundCallback) {
+    const found = [];
+
+    for (const subPath of path) {
+        found.push(subPath);
+        if (object === undefined || object === null) {
+            notFoundCallback(found);
+            return;
+        }
+        object = object[subPath];
+    }
+    callback(object);
+}`;
+}
+
 function parseAssertCssInner(parser, assertFalse) {
     const jsonValidator = {
         kind: 'json',
@@ -167,6 +184,7 @@ function parseAssertObjPropertyInner(parser, assertFalse, objName) {
         kind: 'json',
         keyTypes: {
             'string': [],
+            'object-path': [],
         },
         valueTypes: {
             'string': {},
@@ -233,32 +251,41 @@ function parseAssertObjPropertyInner(parser, assertFalse, objName) {
         return {
             'instructions': [],
             'wait': false,
-            'warnings': warnings.length > 0 ? warnings : undefined,
+            'warnings': warnings,
             'checkResult': true,
         };
     }
 
-    const varName = 'parseAssertDictProp';
+    const varName = 'parseAssertObj';
 
     const varDict = varName + 'Dict';
     const varKey = varName + 'Key';
     const varValue = varName + 'Value';
     // JSON.stringify produces a problematic output so instead we use this.
-    const values = [];
+    const props = [];
     const undefProps = [];
     for (const [k, v] of json_dict) {
+        const k_s = v.key.kind === 'object-path' ? k : `["${k}"]`;
         if (v.kind !== 'ident') {
-            values.push(`"${k}":"${v.value}"`);
+            props.push(`[${k_s},"${v.value}"]`);
         } else {
-            undefProps.push(`"${k}"`);
+            undefProps.push(k_s);
         }
+    }
+    if (props.length + undefProps.length === 0) {
+        // Unlike when elements are involved, if there are no checks, we can return early
+        // because we don't care whether or not the element exists.
+        return {
+            'instructions': [],
+            'wait': false,
+        };
     }
     const { checks, hasSpecialChecks } = makeExtendedChecks(
         enabledChecks,
         assertFalse,
         'nonMatchingProps',
         `${objName} property`,
-        varName,
+        'prop',
         varKey,
         varValue,
     );
@@ -268,37 +295,47 @@ function parseAssertObjPropertyInner(parser, assertFalse, objName) {
         warnings.push(`Special checks (${k}) will be ignored for \`null\``);
     }
 
-    let err = '';
-    let unexpectedPropError = '';
     let expectedPropError = '';
+    let unexpectedPropError = '';
+    let unknown = '';
     if (!assertFalse) {
-        err = '\n';
-        err += indentString(`nonMatchingProps.push('Unknown ${objName} property \`' + ${varKey} + \
-'\`');`, 3);
-        unexpectedPropError = `
-            nonMatchingProps.push("Expected property \`" + prop + "\` to not exist, found: \
-\`" + ${objName}[prop] + "\`");`;
+        unknown = `
+const p = ${varKey}.map(p => \`"\${p}"\`).join('.');
+nonMatchingProps.push('Unknown ${objName} property \`' + p + '\`');`;
+        unexpectedPropError = `\
+const p = prop.map(p => \`"\${p}"\`).join('.');
+nonMatchingProps.push("Expected property \`" + p + "\` to not exist, found: \`" + val + "\`");`;
     } else {
         expectedPropError = `
-        nonMatchingProps.push("Property named \`" + prop + "\` doesn't exist");`;
+const p = prop.map(p => \`"\${p}"\`).join('.');
+nonMatchingProps.push("Property named \`" + p + "\` doesn't exist");`;
     }
 
     const instructions = [`\
 await page.evaluate(() => {
+${indentString(generateCheckObjectPaths(), 1)}
+
     const nonMatchingProps = [];
-    const ${varDict} = {${values.join(',')}};
+    const ${varDict} = [${props.join(',')}];
     const undefProps = [${undefProps.join(',')}];
     for (const prop of undefProps) {
-        if (${objName}[prop] !== undefined && ${objName}[prop] !== null) {${unexpectedPropError}
-            continue;
-        }${expectedPropError}
+        checkObjectPaths(${objName}, prop, val => {
+            if (val !== undefined && val !== null) {
+${indentString(unexpectedPropError, 4)}
+                return;
+            }${indentString(expectedPropError, 3)}
+        }, prop => {${indentString(expectedPropError, 3)}
+        });
     }
-    for (const [${varKey}, ${varValue}] of Object.entries(${varDict})) {
-        if (${objName}[${varKey}] === undefined) {${err}
-            continue;
-        }
-        const ${varName} = String(${objName}[${varKey}]);
-${indentString(checks.join('\n'), 2)}
+    for (const [${varKey}, ${varValue}] of ${varDict}) {
+        checkObjectPaths(${objName}, ${varKey}, val => {
+            if (val === undefined && val === null) {${indentString(unknown, 4)}
+                return;
+            }
+            const prop = String(val);
+${indentString(checks.join('\n'), 3)}
+        }, ${varKey} => {${indentString(unknown, 3)}
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join("; ");
@@ -309,47 +346,47 @@ ${indentString(checks.join('\n'), 2)}
     return {
         'instructions': instructions,
         'wait': false,
-        'warnings': warnings.length > 0 ? warnings : undefined,
+        'warnings': warnings,
         'checkResult': true,
     };
 }
 
 // Possible inputs:
 //
-// * {"DOM property": "value"}
-// * ({"DOM property": "value"})
-// * ({"DOM property": "value"}, CONTAINS|ENDS_WITH|STARTS_WITH|NEAR)
-// * ({"DOM property": "value"}, [CONTAINS|ENDS_WITH|STARTS_WITH|NEAR])
+// * {"DOM property"|object path: "value"}
+// * ({"DOM property"|object path: "value"})
+// * ({"DOM property"|object path: "value"}, CONTAINS|ENDS_WITH|STARTS_WITH|NEAR)
+// * ({"DOM property"|object path: "value"}, [CONTAINS|ENDS_WITH|STARTS_WITH|NEAR])
 function parseAssertDocumentProperty(parser) {
     return parseAssertObjPropertyInner(parser, false, 'document');
 }
 
 // Possible inputs:
 //
-// * {"DOM property": "value"}
-// * ({"DOM property": "value"})
-// * ({"DOM property": "value"}, CONTAINS|ENDS_WITH|STARTS_WITH|NEAR)
-// * ({"DOM property": "value"}, [CONTAINS|ENDS_WITH|STARTS_WITH|NEAR])
+// * {"DOM property"|object path: "value"}
+// * ({"DOM property"|object path: "value"})
+// * ({"DOM property"|object path: "value"}, CONTAINS|ENDS_WITH|STARTS_WITH|NEAR)
+// * ({"DOM property"|object path: "value"}, [CONTAINS|ENDS_WITH|STARTS_WITH|NEAR])
 function parseAssertDocumentPropertyFalse(parser) {
     return parseAssertObjPropertyInner(parser, true, 'document');
 }
 
 // Possible inputs:
 //
-// * {"DOM property": "value"}
-// * ({"DOM property": "value"})
-// * ({"DOM property": "value"}, CONTAINS|ENDS_WITH|STARTS_WITH|NEAR)
-// * ({"DOM property": "value"}, [CONTAINS|ENDS_WITH|STARTS_WITH|NEAR])
+// * {"DOM property"|object path: "value"}
+// * ({"DOM property"|object path: "value"})
+// * ({"DOM property"|object path: "value"}, CONTAINS|ENDS_WITH|STARTS_WITH|NEAR)
+// * ({"DOM property"|object path: "value"}, [CONTAINS|ENDS_WITH|STARTS_WITH|NEAR])
 function parseAssertWindowProperty(parser) {
     return parseAssertObjPropertyInner(parser, false, 'window');
 }
 
 // Possible inputs:
 //
-// * {"DOM property": "value"}
-// * ({"DOM property": "value"})
-// * ({"DOM property": "value"}, CONTAINS|ENDS_WITH|STARTS_WITH|NEAR)
-// * ({"DOM property": "value"}, [CONTAINS|ENDS_WITH|STARTS_WITH|NEAR])
+// * {"DOM property"|object path: "value"}
+// * ({"DOM property"|object path: "value"})
+// * ({"DOM property"|object path: "value"}, CONTAINS|ENDS_WITH|STARTS_WITH|NEAR)
+// * ({"DOM property"|object path: "value"}, [CONTAINS|ENDS_WITH|STARTS_WITH|NEAR])
 function parseAssertWindowPropertyFalse(parser) {
     return parseAssertObjPropertyInner(parser, true, 'window');
 }
@@ -441,13 +478,6 @@ function parseAssertPropertyInner(parser, assertFalse) {
         }
     }
 
-    if (props.length + undefProps.length === 0) {
-        return {
-            'instructions': [],
-            'wait': false,
-        };
-    }
-
     const isPseudo = !selector.isXPath && selector.pseudo !== null;
     if (isPseudo) {
         warnings.push(`Pseudo-elements (\`${selector.pseudo}\`) don't have properties so \
@@ -465,12 +495,11 @@ the check will be performed on the element itself`);
     if (!assertFalse) {
         unknown = `\
 const p = ${varKey}.map(p => \`"\${p}"\`).join('.');
-nonMatchingProps.push('Unknown property \`' + ${varKey} + '\`');
+nonMatchingProps.push('Unknown property \`' + p + '\`');
 `;
         unexpectedPropError = `\
 const p = prop.map(p => \`"\${p}"\`).join('.');
 nonMatchingProps.push("Expected property \`" + p + "\` to not exist, found: \`" + val + "\`");`;
-
     } else {
         expectedPropError = `
 const p = prop.map(p => \`"\${p}"\`).join('.');
@@ -485,19 +514,7 @@ nonMatchingProps.push("Property named \`" + p + "\` doesn't exist");`;
     }
     whole += indentString(`\
 await page.evaluate(e => {
-    function checkObjectPaths(object, path, callback, notFoundCallback) {
-        const found = [];
-
-        for (const subPath of path) {
-            found.push(subPath);
-            if (object === undefined || object === null) {
-                notFoundCallback(found);
-                return;
-            }
-            object = object[subPath];
-        }
-        callback(object);
-    }
+${indentString(generateCheckObjectPaths(), 1)}
 
     const nonMatchingProps = [];
     const ${varDict} = [${props.join(',')}];

--- a/src/parser.js
+++ b/src/parser.js
@@ -1758,8 +1758,8 @@ found \`${el.getErrorText()}\` (${el.getArticleKind()})`;
                 ) {
                     const article = elems[0].getArticleKind();
                     const extra = ` (\`${elems[0].getErrorText()}\`)`;
-                    keyError(`only strings can be used as keys in JSON dict, found \
-${article}${extra}`);
+                    keyError(`only strings and object paths can be used as keys in JSON dict, \
+found ${article}${extra}`);
                 } else if (ender === '}' || ender === ',') {
                     const after = elems[0].getErrorText();
                     keyError(`expected \`:\` after \`${after}\`, found \`${ender}\``);

--- a/tests/api-output/parseAssertDocumentProperty/basic-1.toml
+++ b/tests/api-output/parseAssertDocumentProperty/basic-1.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown document property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp !== parseAssertDictPropValue) {
-            nonMatchingProps.push(\"expected `\" + parseAssertDictPropValue + \"` for document property `\" + parseAssertDictPropKey + \"`, found `\" + parseAssertDictProp + \"`\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (prop !== parseAssertObjValue) {
+                nonMatchingProps.push(\"expected `\" + parseAssertObjValue + \"` for document property `\" + parseAssertObjKey + \"`, found `\" + prop + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -26,4 +50,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentProperty/basic-2.toml
+++ b/tests/api-output/parseAssertDocumentProperty/basic-2.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown document property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp !== parseAssertDictPropValue) {
-            nonMatchingProps.push(\"expected `\" + parseAssertDictPropValue + \"` for document property `\" + parseAssertDictPropKey + \"`, found `\" + parseAssertDictProp + \"`\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (prop !== parseAssertObjValue) {
+                nonMatchingProps.push(\"expected `\" + parseAssertObjValue + \"` for document property `\" + parseAssertObjKey + \"`, found `\" + prop + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -26,4 +50,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentProperty/extra-1.toml
+++ b/tests/api-output/parseAssertDocumentProperty/extra-1.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown document property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.includes(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't contain `\" + parseAssertDictPropValue + \"` (for CONTAINS check)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.includes(parseAssertObjValue)) {
+                nonMatchingProps.push(\"document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't contain `\" + parseAssertObjValue + \"` (for CONTAINS check)\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -26,4 +50,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentProperty/extra-2.toml
+++ b/tests/api-output/parseAssertDocumentProperty/extra-2.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown document property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't start with `\" + parseAssertDictPropValue + \"` (for STARTS_WITH check)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't start with `\" + parseAssertObjValue + \"` (for STARTS_WITH check)\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -26,4 +50,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentProperty/extra-3.toml
+++ b/tests/api-output/parseAssertDocumentProperty/extra-3.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown document property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.endsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't end with `\" + parseAssertDictPropValue + \"`\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.endsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't end with `\" + parseAssertObjValue + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -26,4 +50,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentProperty/extra-4.toml
+++ b/tests/api-output/parseAssertDocumentProperty/extra-4.toml
@@ -1,26 +1,50 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown document property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't start with `\" + parseAssertDictPropValue + \"` (for STARTS_WITH check)\");
-        }
-        if (!parseAssertDictProp.endsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't end with `\" + parseAssertDictPropValue + \"`\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't start with `\" + parseAssertObjValue + \"` (for STARTS_WITH check)\");
+            }
+            if (!prop.endsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't end with `\" + parseAssertObjValue + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -29,4 +53,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentProperty/extra-5.toml
+++ b/tests/api-output/parseAssertDocumentProperty/extra-5.toml
@@ -1,32 +1,56 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown document property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't start with `\" + parseAssertDictPropValue + \"` (for STARTS_WITH check)\");
-        }
-        const tmpNb = parseFloat(parseAssertDictProp);
-        const tmpNb2 = parseFloat(parseAssertDictPropValue);
-        if (Number.isNaN(tmpNb)) {
-            nonMatchingProps.push('document property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is NaN (for NEAR check)');
-        } else if (Number.isNaN(tmpNb2)) {
-            nonMatchingProps.push('provided value for `' + parseAssertDictPropKey + '` is NaN (for NEAR check)');
-        } else if (Math.abs(parseAssertDictProp - parseAssertDictPropValue) > 1) {
-            nonMatchingProps.push('document property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is not within 1 of `' + parseAssertDictPropValue + '` (for NEAR check)');
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't start with `\" + parseAssertObjValue + \"` (for STARTS_WITH check)\");
+            }
+            const tmpNb = parseFloat(prop);
+            const tmpNb2 = parseFloat(parseAssertObjValue);
+            if (Number.isNaN(tmpNb)) {
+                nonMatchingProps.push('document property `' + parseAssertObjKey + '` (`' + prop + '`) is NaN (for NEAR check)');
+            } else if (Number.isNaN(tmpNb2)) {
+                nonMatchingProps.push('provided value for `' + parseAssertObjKey + '` is NaN (for NEAR check)');
+            } else if (Math.abs(prop - parseAssertObjValue) > 1) {
+                nonMatchingProps.push('document property `' + parseAssertObjKey + '` (`' + prop + '`) is not within 1 of `' + parseAssertObjValue + '` (for NEAR check)');
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -35,4 +59,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentProperty/null-2.toml
+++ b/tests/api-output/parseAssertDocumentProperty/null-2.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown document property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp !== parseAssertDictPropValue) {
-            nonMatchingProps.push(\"expected `\" + parseAssertDictPropValue + \"` for document property `\" + parseAssertDictPropKey + \"`, found `\" + parseAssertDictProp + \"`\");
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (prop !== parseAssertObjValue) {
+                nonMatchingProps.push(\"expected `\" + parseAssertObjValue + \"` for document property `\" + parseAssertObjKey + \"`, found `\" + prop + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -26,4 +50,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentProperty/null-3.toml
+++ b/tests/api-output/parseAssertDocumentProperty/null-3.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown document property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.endsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't end with `\" + parseAssertDictPropValue + \"`\");
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.endsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't end with `\" + parseAssertObjValue + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertDocumentProperty/null-4.toml
+++ b/tests/api-output/parseAssertDocumentProperty/null-4.toml
@@ -1,32 +1,56 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown document property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't start with `\" + parseAssertDictPropValue + \"` (for STARTS_WITH check)\");
-        }
-        const tmpNb = parseFloat(parseAssertDictProp);
-        const tmpNb2 = parseFloat(parseAssertDictPropValue);
-        if (Number.isNaN(tmpNb)) {
-            nonMatchingProps.push('document property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is NaN (for NEAR check)');
-        } else if (Number.isNaN(tmpNb2)) {
-            nonMatchingProps.push('provided value for `' + parseAssertDictPropKey + '` is NaN (for NEAR check)');
-        } else if (Math.abs(parseAssertDictProp - parseAssertDictPropValue) > 1) {
-            nonMatchingProps.push('document property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is not within 1 of `' + parseAssertDictPropValue + '` (for NEAR check)');
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't start with `\" + parseAssertObjValue + \"` (for STARTS_WITH check)\");
+            }
+            const tmpNb = parseFloat(prop);
+            const tmpNb2 = parseFloat(parseAssertObjValue);
+            if (Number.isNaN(tmpNb)) {
+                nonMatchingProps.push('document property `' + parseAssertObjKey + '` (`' + prop + '`) is NaN (for NEAR check)');
+            } else if (Number.isNaN(tmpNb2)) {
+                nonMatchingProps.push('provided value for `' + parseAssertObjKey + '` is NaN (for NEAR check)');
+            } else if (Math.abs(prop - parseAssertObjValue) > 1) {
+                nonMatchingProps.push('document property `' + parseAssertObjKey + '` (`' + prop + '`) is not within 1 of `' + parseAssertObjValue + '` (for NEAR check)');
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertDocumentProperty/null-5.toml
+++ b/tests/api-output/parseAssertDocumentProperty/null-5.toml
@@ -1,32 +1,56 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"b\":\"12\"};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown document property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't start with `\" + parseAssertDictPropValue + \"` (for STARTS_WITH check)\");
-        }
-        const tmpNb = parseFloat(parseAssertDictProp);
-        const tmpNb2 = parseFloat(parseAssertDictPropValue);
-        if (Number.isNaN(tmpNb)) {
-            nonMatchingProps.push('document property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is NaN (for NEAR check)');
-        } else if (Number.isNaN(tmpNb2)) {
-            nonMatchingProps.push('provided value for `' + parseAssertDictPropKey + '` is NaN (for NEAR check)');
-        } else if (Math.abs(parseAssertDictProp - parseAssertDictPropValue) > 1) {
-            nonMatchingProps.push('document property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is not within 1 of `' + parseAssertDictPropValue + '` (for NEAR check)');
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [[[\"b\"],\"12\"]];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't start with `\" + parseAssertObjValue + \"` (for STARTS_WITH check)\");
+            }
+            const tmpNb = parseFloat(prop);
+            const tmpNb2 = parseFloat(parseAssertObjValue);
+            if (Number.isNaN(tmpNb)) {
+                nonMatchingProps.push('document property `' + parseAssertObjKey + '` (`' + prop + '`) is NaN (for NEAR check)');
+            } else if (Number.isNaN(tmpNb2)) {
+                nonMatchingProps.push('provided value for `' + parseAssertObjKey + '` is NaN (for NEAR check)');
+            } else if (Math.abs(prop - parseAssertObjValue) > 1) {
+                nonMatchingProps.push('document property `' + parseAssertObjKey + '` (`' + prop + '`) is not within 1 of `' + parseAssertObjValue + '` (for NEAR check)');
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertDocumentProperty/object-path-1.toml
+++ b/tests/api-output/parseAssertDocumentProperty/object-path-1.toml
@@ -1,0 +1,55 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [[[\"a\",\"b\"],\"b\"]];
+    const undefProps = [];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (prop !== parseAssertObjValue) {
+                nonMatchingProps.push(\"expected `\" + parseAssertObjValue + \"` for document property `\" + parseAssertObjKey + \"`, found `\" + prop + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertDocumentProperty/object-path-2.toml
+++ b/tests/api-output/parseAssertDocumentProperty/object-path-2.toml
@@ -1,0 +1,55 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [[[\"a\",\"b\"],\"b\"]];
+    const undefProps = [];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.includes(parseAssertObjValue)) {
+                nonMatchingProps.push(\"document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't contain `\" + parseAssertObjValue + \"` (for CONTAINS check)\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertDocumentProperty/object-path-3.toml
+++ b/tests/api-output/parseAssertDocumentProperty/object-path-3.toml
@@ -1,0 +1,55 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\",\"b\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (prop !== parseAssertObjValue) {
+                nonMatchingProps.push(\"expected `\" + parseAssertObjValue + \"` for document property `\" + parseAssertObjKey + \"`, found `\" + prop + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertDocumentProperty/object-path-4.toml
+++ b/tests/api-output/parseAssertDocumentProperty/object-path-4.toml
@@ -1,0 +1,56 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\",\"b\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown document property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.includes(parseAssertObjValue)) {
+                nonMatchingProps.push(\"document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't contain `\" + parseAssertObjValue + \"` (for CONTAINS check)\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown document property `' + p + '`');
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+  """Special checks (CONTAINS) will be ignored for `null`""",
+]
+checkResult = true

--- a/tests/api-output/parseAssertDocumentPropertyFalse/basic-1.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/basic-1.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp === parseAssertDictPropValue) {
-            nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop === parseAssertObjValue) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -25,4 +49,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentPropertyFalse/basic-2.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/basic-2.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp === parseAssertDictPropValue) {
-            nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop === parseAssertObjValue) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -25,4 +49,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentPropertyFalse/extra-1.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/extra-1.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp.includes(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for CONTAINS check)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.includes(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for CONTAINS check)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -25,4 +49,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentPropertyFalse/extra-2.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/extra-2.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for STARTS_WITH check)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -25,4 +49,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentPropertyFalse/extra-3.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/extra-3.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp.endsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for ENDS_WITH check)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.endsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for ENDS_WITH check)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -25,4 +49,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentPropertyFalse/extra-4.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/extra-4.toml
@@ -1,25 +1,49 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for STARTS_WITH check)\");
-        }
-        if (parseAssertDictProp.endsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for ENDS_WITH check)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
+            }
+            if (prop.endsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for ENDS_WITH check)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -28,4 +52,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentPropertyFalse/extra-5.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/extra-5.toml
@@ -1,31 +1,55 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for STARTS_WITH check)\");
-        }
-        const tmpNb = parseFloat(parseAssertDictProp);
-        const tmpNb2 = parseFloat(parseAssertDictPropValue);
-        if (Number.isNaN(tmpNb)) {
-            nonMatchingProps.push('document property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is NaN (for NEAR check)');
-        } else if (Number.isNaN(tmpNb2)) {
-            nonMatchingProps.push('provided value for `' + parseAssertDictPropKey + '` is NaN (for NEAR check)');
-        } else if (Math.abs(tmpNb - tmpNb2) <= 1) {
-            nonMatchingProps.push('document property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is within 1 of `' + parseAssertDictPropValue + '` (for NEAR check)');
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
+            }
+            const tmpNb = parseFloat(prop);
+            const tmpNb2 = parseFloat(parseAssertObjValue);
+            if (Number.isNaN(tmpNb)) {
+                nonMatchingProps.push('document property `' + parseAssertObjKey + '` (`' + prop + '`) is NaN (for NEAR check)');
+            } else if (Number.isNaN(tmpNb2)) {
+                nonMatchingProps.push('provided value for `' + parseAssertObjKey + '` is NaN (for NEAR check)');
+            } else if (Math.abs(tmpNb - tmpNb2) <= 1) {
+                nonMatchingProps.push('document property `' + parseAssertObjKey + '` (`' + prop + '`) is within 1 of `' + parseAssertObjValue + '` (for NEAR check)');
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -34,4 +58,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentPropertyFalse/null-2.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/null-2.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp === parseAssertDictPropValue) {
-            nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`)\");
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop === parseAssertObjValue) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -25,4 +49,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertDocumentPropertyFalse/null-3.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/null-3.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp.endsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for ENDS_WITH check)\");
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.endsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for ENDS_WITH check)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertDocumentPropertyFalse/null-4.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/null-4.toml
@@ -1,31 +1,55 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for STARTS_WITH check)\");
-        }
-        const tmpNb = parseFloat(parseAssertDictProp);
-        const tmpNb2 = parseFloat(parseAssertDictPropValue);
-        if (Number.isNaN(tmpNb)) {
-            nonMatchingProps.push('document property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is NaN (for NEAR check)');
-        } else if (Number.isNaN(tmpNb2)) {
-            nonMatchingProps.push('provided value for `' + parseAssertDictPropKey + '` is NaN (for NEAR check)');
-        } else if (Math.abs(tmpNb - tmpNb2) <= 1) {
-            nonMatchingProps.push('document property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is within 1 of `' + parseAssertDictPropValue + '` (for NEAR check)');
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
+            }
+            const tmpNb = parseFloat(prop);
+            const tmpNb2 = parseFloat(parseAssertObjValue);
+            if (Number.isNaN(tmpNb)) {
+                nonMatchingProps.push('document property `' + parseAssertObjKey + '` (`' + prop + '`) is NaN (for NEAR check)');
+            } else if (Number.isNaN(tmpNb2)) {
+                nonMatchingProps.push('provided value for `' + parseAssertObjKey + '` is NaN (for NEAR check)');
+            } else if (Math.abs(tmpNb - tmpNb2) <= 1) {
+                nonMatchingProps.push('document property `' + parseAssertObjKey + '` (`' + prop + '`) is within 1 of `' + parseAssertObjValue + '` (for NEAR check)');
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertDocumentPropertyFalse/null-5.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/null-5.toml
@@ -1,31 +1,55 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"b\":\"12\"};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (document[prop] !== undefined && document[prop] !== null) {
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (document[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(document[parseAssertDictPropKey]);
-        if (parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for STARTS_WITH check)\");
-        }
-        const tmpNb = parseFloat(parseAssertDictProp);
-        const tmpNb2 = parseFloat(parseAssertDictPropValue);
-        if (Number.isNaN(tmpNb)) {
-            nonMatchingProps.push('document property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is NaN (for NEAR check)');
-        } else if (Number.isNaN(tmpNb2)) {
-            nonMatchingProps.push('provided value for `' + parseAssertDictPropKey + '` is NaN (for NEAR check)');
-        } else if (Math.abs(tmpNb - tmpNb2) <= 1) {
-            nonMatchingProps.push('document property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is within 1 of `' + parseAssertDictPropValue + '` (for NEAR check)');
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [[[\"b\"],\"12\"]];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
+            }
+            const tmpNb = parseFloat(prop);
+            const tmpNb2 = parseFloat(parseAssertObjValue);
+            if (Number.isNaN(tmpNb)) {
+                nonMatchingProps.push('document property `' + parseAssertObjKey + '` (`' + prop + '`) is NaN (for NEAR check)');
+            } else if (Number.isNaN(tmpNb2)) {
+                nonMatchingProps.push('provided value for `' + parseAssertObjKey + '` is NaN (for NEAR check)');
+            } else if (Math.abs(tmpNb - tmpNb2) <= 1) {
+                nonMatchingProps.push('document property `' + parseAssertObjKey + '` (`' + prop + '`) is within 1 of `' + parseAssertObjValue + '` (for NEAR check)');
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertDocumentPropertyFalse/object-path-1.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/object-path-1.toml
@@ -1,0 +1,54 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [[[\"a\",\"b\"],\"b\"]];
+    const undefProps = [];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop === parseAssertObjValue) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`)\");
+            }
+        }, parseAssertObjKey => {
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertDocumentPropertyFalse/object-path-2.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/object-path-2.toml
@@ -1,0 +1,54 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [[[\"a\",\"b\"],\"b\"]];
+    const undefProps = [];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.includes(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for CONTAINS check)\");
+            }
+        }, parseAssertObjKey => {
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertDocumentPropertyFalse/object-path-3.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/object-path-3.toml
@@ -1,0 +1,54 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\",\"b\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop === parseAssertObjValue) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`)\");
+            }
+        }, parseAssertObjKey => {
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertDocumentPropertyFalse/object-path-4.toml
+++ b/tests/api-output/parseAssertDocumentPropertyFalse/object-path-4.toml
@@ -1,0 +1,55 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\",\"b\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(document, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(document, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.includes(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for document property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for CONTAINS check)\");
+            }
+        }, parseAssertObjKey => {
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+  """Special checks (CONTAINS) will be ignored for `null`""",
+]
+checkResult = true

--- a/tests/api-output/parseAssertProperty/basic-1.toml
+++ b/tests/api-output/parseAssertProperty/basic-1.toml
@@ -1,3 +1,59 @@
 instructions = [
+  """let parseAssertElemProp = await page.$(\"a\");
+if (parseAssertElemProp === null) { throw '\"a\" not found'; }
+await page.evaluate(e => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertElemPropDict = [];
+    const undefProps = [];
+    for (const prop of undefProps) {
+        checkObjectPaths(e, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+
+        }, prop => {
+
+        });
+    }
+    for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
+        checkObjectPaths(e, parseAssertElemPropKey, val => {
+            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown property `' + p + '`');
+
+                return;
+            }
+            const prop = String(val);
+            if (prop !== parseAssertElemPropValue) {
+                nonMatchingProps.push(\"expected `\" + parseAssertElemPropValue + \"` for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"`, found `\" + prop + \"`\");
+            }
+        }, parseAssertElemPropKey => {
+            const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown property `' + p + '`');
+});
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened (for selector `a`): [\" + props + \"]\";
+    }
+}, parseAssertElemProp);""",
 ]
 wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertProperty/basic-1.toml
+++ b/tests/api-output/parseAssertProperty/basic-1.toml
@@ -26,16 +26,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -45,7 +43,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/basic-2.toml
+++ b/tests/api-output/parseAssertProperty/basic-2.toml
@@ -34,7 +34,7 @@ await page.evaluate(e => {
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
             if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
 
                 return;
             }
@@ -44,7 +44,7 @@ await page.evaluate(e => {
             }
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-            nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+            nonMatchingProps.push('Unknown property `' + p + '`');
 });
     }
     if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/basic-2.toml
+++ b/tests/api-output/parseAssertProperty/basic-2.toml
@@ -26,16 +26,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -45,7 +43,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/basic-3.toml
+++ b/tests/api-output/parseAssertProperty/basic-3.toml
@@ -27,16 +27,14 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                     return;
                 }
-
             }, prop => {
-
             });
         }
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
-                if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+                if (val === undefined && val === null) {
+                    const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                     nonMatchingProps.push('Unknown property `' + p + '`');
-
                     return;
                 }
                 const prop = String(val);
@@ -46,7 +44,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/basic-3.toml
+++ b/tests/api-output/parseAssertProperty/basic-3.toml
@@ -35,7 +35,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
                 if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                    nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                    nonMatchingProps.push('Unknown property `' + p + '`');
 
                     return;
                 }
@@ -45,7 +45,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                 }
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
     });
         }
         if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/extra-1.toml
+++ b/tests/api-output/parseAssertProperty/extra-1.toml
@@ -34,7 +34,7 @@ await page.evaluate(e => {
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
             if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
 
                 return;
             }
@@ -44,7 +44,7 @@ await page.evaluate(e => {
             }
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-            nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+            nonMatchingProps.push('Unknown property `' + p + '`');
 });
     }
     if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/extra-1.toml
+++ b/tests/api-output/parseAssertProperty/extra-1.toml
@@ -26,16 +26,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -45,7 +43,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/extra-2.toml
+++ b/tests/api-output/parseAssertProperty/extra-2.toml
@@ -34,7 +34,7 @@ await page.evaluate(e => {
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
             if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
 
                 return;
             }
@@ -44,7 +44,7 @@ await page.evaluate(e => {
             }
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-            nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+            nonMatchingProps.push('Unknown property `' + p + '`');
 });
     }
     if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/extra-2.toml
+++ b/tests/api-output/parseAssertProperty/extra-2.toml
@@ -26,16 +26,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -45,7 +43,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/extra-3.toml
+++ b/tests/api-output/parseAssertProperty/extra-3.toml
@@ -26,16 +26,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -48,7 +46,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/extra-3.toml
+++ b/tests/api-output/parseAssertProperty/extra-3.toml
@@ -34,7 +34,7 @@ await page.evaluate(e => {
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
             if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
 
                 return;
             }
@@ -47,7 +47,7 @@ await page.evaluate(e => {
             }
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-            nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+            nonMatchingProps.push('Unknown property `' + p + '`');
 });
     }
     if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/multiline-2.toml
+++ b/tests/api-output/parseAssertProperty/multiline-2.toml
@@ -27,16 +27,14 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                     return;
                 }
-
             }, prop => {
-
             });
         }
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
-                if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+                if (val === undefined && val === null) {
+                    const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                     nonMatchingProps.push('Unknown property `' + p + '`');
-
                     return;
                 }
                 const prop = String(val);
@@ -46,7 +44,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/multiline-2.toml
+++ b/tests/api-output/parseAssertProperty/multiline-2.toml
@@ -35,7 +35,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
                 if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                    nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                    nonMatchingProps.push('Unknown property `' + p + '`');
 
                     return;
                 }
@@ -45,7 +45,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                 }
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
     });
         }
         if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/object-path-1.toml
+++ b/tests/api-output/parseAssertProperty/object-path-1.toml
@@ -34,7 +34,7 @@ await page.evaluate(e => {
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
             if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
 
                 return;
             }
@@ -44,7 +44,7 @@ await page.evaluate(e => {
             }
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-            nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+            nonMatchingProps.push('Unknown property `' + p + '`');
 });
     }
     if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/object-path-1.toml
+++ b/tests/api-output/parseAssertProperty/object-path-1.toml
@@ -26,16 +26,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -45,7 +43,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/object-path-2.toml
+++ b/tests/api-output/parseAssertProperty/object-path-2.toml
@@ -27,16 +27,14 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                     return;
                 }
-
             }, prop => {
-
             });
         }
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
-                if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+                if (val === undefined && val === null) {
+                    const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                     nonMatchingProps.push('Unknown property `' + p + '`');
-
                     return;
                 }
                 const prop = String(val);
@@ -46,7 +44,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/object-path-2.toml
+++ b/tests/api-output/parseAssertProperty/object-path-2.toml
@@ -35,7 +35,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
                 if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                    nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                    nonMatchingProps.push('Unknown property `' + p + '`');
 
                     return;
                 }
@@ -45,7 +45,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                 }
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
     });
         }
         if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/pseudo-1.toml
+++ b/tests/api-output/parseAssertProperty/pseudo-1.toml
@@ -34,7 +34,7 @@ await page.evaluate(e => {
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
             if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
 
                 return;
             }
@@ -44,7 +44,7 @@ await page.evaluate(e => {
             }
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-            nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+            nonMatchingProps.push('Unknown property `' + p + '`');
 });
     }
     if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/pseudo-1.toml
+++ b/tests/api-output/parseAssertProperty/pseudo-1.toml
@@ -26,16 +26,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -45,7 +43,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/pseudo-2.toml
+++ b/tests/api-output/parseAssertProperty/pseudo-2.toml
@@ -27,16 +27,14 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                     return;
                 }
-
             }, prop => {
-
             });
         }
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
-                if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+                if (val === undefined && val === null) {
+                    const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                     nonMatchingProps.push('Unknown property `' + p + '`');
-
                     return;
                 }
                 const prop = String(val);
@@ -46,7 +44,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/pseudo-2.toml
+++ b/tests/api-output/parseAssertProperty/pseudo-2.toml
@@ -35,7 +35,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
                 if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                    nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                    nonMatchingProps.push('Unknown property `' + p + '`');
 
                     return;
                 }
@@ -45,7 +45,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                 }
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
     });
         }
         if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/pseudo-3.toml
+++ b/tests/api-output/parseAssertProperty/pseudo-3.toml
@@ -34,7 +34,7 @@ await page.evaluate(e => {
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
             if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
 
                 return;
             }
@@ -44,7 +44,7 @@ await page.evaluate(e => {
             }
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-            nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+            nonMatchingProps.push('Unknown property `' + p + '`');
 });
     }
     if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/pseudo-3.toml
+++ b/tests/api-output/parseAssertProperty/pseudo-3.toml
@@ -26,16 +26,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -45,7 +43,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/pseudo-4.toml
+++ b/tests/api-output/parseAssertProperty/pseudo-4.toml
@@ -27,16 +27,14 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                     return;
                 }
-
             }, prop => {
-
             });
         }
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
-                if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+                if (val === undefined && val === null) {
+                    const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                     nonMatchingProps.push('Unknown property `' + p + '`');
-
                     return;
                 }
                 const prop = String(val);
@@ -46,7 +44,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/pseudo-4.toml
+++ b/tests/api-output/parseAssertProperty/pseudo-4.toml
@@ -35,7 +35,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
                 if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                    nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                    nonMatchingProps.push('Unknown property `' + p + '`');
 
                     return;
                 }
@@ -45,7 +45,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                 }
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
     });
         }
         if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/pseudo-5.toml
+++ b/tests/api-output/parseAssertProperty/pseudo-5.toml
@@ -34,7 +34,7 @@ await page.evaluate(e => {
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
             if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
 
                 return;
             }
@@ -44,7 +44,7 @@ await page.evaluate(e => {
             }
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-            nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+            nonMatchingProps.push('Unknown property `' + p + '`');
 });
     }
     if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/pseudo-5.toml
+++ b/tests/api-output/parseAssertProperty/pseudo-5.toml
@@ -26,16 +26,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -45,7 +43,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/pseudo-6.toml
+++ b/tests/api-output/parseAssertProperty/pseudo-6.toml
@@ -27,16 +27,14 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                     return;
                 }
-
             }, prop => {
-
             });
         }
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
-                if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+                if (val === undefined && val === null) {
+                    const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                     nonMatchingProps.push('Unknown property `' + p + '`');
-
                     return;
                 }
                 const prop = String(val);
@@ -46,7 +44,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/pseudo-6.toml
+++ b/tests/api-output/parseAssertProperty/pseudo-6.toml
@@ -35,7 +35,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
                 if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                    nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                    nonMatchingProps.push('Unknown property `' + p + '`');
 
                     return;
                 }
@@ -45,7 +45,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                 }
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
     });
         }
         if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/undef-1.toml
+++ b/tests/api-output/parseAssertProperty/undef-1.toml
@@ -34,7 +34,7 @@ await page.evaluate(e => {
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
             if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
 
                 return;
             }
@@ -44,7 +44,7 @@ await page.evaluate(e => {
             }
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-            nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+            nonMatchingProps.push('Unknown property `' + p + '`');
 });
     }
     if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/undef-1.toml
+++ b/tests/api-output/parseAssertProperty/undef-1.toml
@@ -26,16 +26,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -45,7 +43,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/undef-2.toml
+++ b/tests/api-output/parseAssertProperty/undef-2.toml
@@ -34,7 +34,7 @@ await page.evaluate(e => {
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
             if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
 
                 return;
             }
@@ -44,7 +44,7 @@ await page.evaluate(e => {
             }
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-            nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+            nonMatchingProps.push('Unknown property `' + p + '`');
 });
     }
     if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/undef-2.toml
+++ b/tests/api-output/parseAssertProperty/undef-2.toml
@@ -26,16 +26,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -45,7 +43,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/undef-3.toml
+++ b/tests/api-output/parseAssertProperty/undef-3.toml
@@ -34,7 +34,7 @@ await page.evaluate(e => {
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
             if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
 
                 return;
             }
@@ -44,7 +44,7 @@ await page.evaluate(e => {
             }
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-            nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+            nonMatchingProps.push('Unknown property `' + p + '`');
 });
     }
     if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/undef-3.toml
+++ b/tests/api-output/parseAssertProperty/undef-3.toml
@@ -26,16 +26,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -45,7 +43,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/undef-4.toml
+++ b/tests/api-output/parseAssertProperty/undef-4.toml
@@ -34,7 +34,7 @@ await page.evaluate(e => {
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
             if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
 
                 return;
             }
@@ -44,7 +44,7 @@ await page.evaluate(e => {
             }
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-            nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+            nonMatchingProps.push('Unknown property `' + p + '`');
 });
     }
     if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/undef-4.toml
+++ b/tests/api-output/parseAssertProperty/undef-4.toml
@@ -26,16 +26,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -45,7 +43,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/xpath-1.toml
+++ b/tests/api-output/parseAssertProperty/xpath-1.toml
@@ -27,16 +27,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -46,7 +44,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/xpath-1.toml
+++ b/tests/api-output/parseAssertProperty/xpath-1.toml
@@ -1,3 +1,60 @@
 instructions = [
+  """let parseAssertElemProp = await page.$x(\"//a\");
+if (parseAssertElemProp.length === 0) { throw 'XPath \"//a\" not found'; }
+parseAssertElemProp = parseAssertElemProp[0];
+await page.evaluate(e => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertElemPropDict = [];
+    const undefProps = [];
+    for (const prop of undefProps) {
+        checkObjectPaths(e, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+
+        }, prop => {
+
+        });
+    }
+    for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
+        checkObjectPaths(e, parseAssertElemPropKey, val => {
+            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown property `' + p + '`');
+
+                return;
+            }
+            const prop = String(val);
+            if (prop !== parseAssertElemPropValue) {
+                nonMatchingProps.push(\"expected `\" + parseAssertElemPropValue + \"` for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"`, found `\" + prop + \"`\");
+            }
+        }, parseAssertElemPropKey => {
+            const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown property `' + p + '`');
+});
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened (for XPath `//a`): [\" + props + \"]\";
+    }
+}, parseAssertElemProp);""",
 ]
 wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertProperty/xpath-2.toml
+++ b/tests/api-output/parseAssertProperty/xpath-2.toml
@@ -27,16 +27,14 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                 return;
             }
-
         }, prop => {
-
         });
     }
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
-            if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+            if (val === undefined && val === null) {
+                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-
                 return;
             }
             const prop = String(val);
@@ -46,7 +44,7 @@ await page.evaluate(e => {
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push('Unknown property `' + p + '`');
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/xpath-2.toml
+++ b/tests/api-output/parseAssertProperty/xpath-2.toml
@@ -35,7 +35,7 @@ await page.evaluate(e => {
     for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
         checkObjectPaths(e, parseAssertElemPropKey, val => {
             if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
 
                 return;
             }
@@ -45,7 +45,7 @@ await page.evaluate(e => {
             }
         }, parseAssertElemPropKey => {
             const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-            nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+            nonMatchingProps.push('Unknown property `' + p + '`');
 });
     }
     if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertProperty/xpath-3.toml
+++ b/tests/api-output/parseAssertProperty/xpath-3.toml
@@ -27,16 +27,14 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
                     return;
                 }
-
             }, prop => {
-
             });
         }
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
-                if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
+                if (val === undefined && val === null) {
+                    const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                     nonMatchingProps.push('Unknown property `' + p + '`');
-
                     return;
                 }
                 const prop = String(val);
@@ -46,7 +44,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push('Unknown property `' + p + '`');
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertProperty/xpath-3.toml
+++ b/tests/api-output/parseAssertProperty/xpath-3.toml
@@ -35,7 +35,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
         for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
             checkObjectPaths(e, parseAssertElemPropKey, val => {
                 if (val === undefined && val === null) {                const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                    nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                    nonMatchingProps.push('Unknown property `' + p + '`');
 
                     return;
                 }
@@ -45,7 +45,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                 }
             }, parseAssertElemPropKey => {
                 const p = parseAssertElemPropKey.map(p => `\"${p}\"`).join('.');
-                nonMatchingProps.push('Unknown property `' + parseAssertElemPropKey + '`');
+                nonMatchingProps.push('Unknown property `' + p + '`');
     });
         }
         if (nonMatchingProps.length !== 0) {

--- a/tests/api-output/parseAssertPropertyFalse/basic-1.toml
+++ b/tests/api-output/parseAssertPropertyFalse/basic-1.toml
@@ -1,3 +1,58 @@
 instructions = [
+  """let parseAssertElemProp = await page.$(\"a\");
+if (parseAssertElemProp === null) { throw '\"a\" not found'; }
+await page.evaluate(e => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertElemPropDict = [];
+    const undefProps = [];
+    for (const prop of undefProps) {
+        checkObjectPaths(e, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
+        checkObjectPaths(e, parseAssertElemPropKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop === parseAssertElemPropValue) {
+                nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
+            }
+        }, parseAssertElemPropKey => {
+});
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened (for selector `a`): [\" + props + \"]\";
+    }
+}, parseAssertElemProp);""",
 ]
 wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertPropertyFalse/basic-1.toml
+++ b/tests/api-output/parseAssertPropertyFalse/basic-1.toml
@@ -25,11 +25,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -44,7 +42,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/basic-2.toml
+++ b/tests/api-output/parseAssertPropertyFalse/basic-2.toml
@@ -25,11 +25,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -44,7 +42,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/basic-3.toml
+++ b/tests/api-output/parseAssertPropertyFalse/basic-3.toml
@@ -26,11 +26,9 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
 
                     return;
                 }
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             }, prop => {
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             });
@@ -45,7 +43,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
                 }
             }, parseAssertElemPropKey => {
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/extra-1.toml
+++ b/tests/api-output/parseAssertPropertyFalse/extra-1.toml
@@ -25,11 +25,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -44,7 +42,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/extra-2.toml
+++ b/tests/api-output/parseAssertPropertyFalse/extra-2.toml
@@ -25,11 +25,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -44,7 +42,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/extra-3.toml
+++ b/tests/api-output/parseAssertPropertyFalse/extra-3.toml
@@ -25,11 +25,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -47,7 +45,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`) (for ENDS_WITH check)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/multiline-2.toml
+++ b/tests/api-output/parseAssertPropertyFalse/multiline-2.toml
@@ -26,11 +26,9 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
 
                     return;
                 }
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             }, prop => {
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             });
@@ -45,7 +43,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
                 }
             }, parseAssertElemPropKey => {
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/object-path-1.toml
+++ b/tests/api-output/parseAssertPropertyFalse/object-path-1.toml
@@ -25,11 +25,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -44,7 +42,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/object-path-2.toml
+++ b/tests/api-output/parseAssertPropertyFalse/object-path-2.toml
@@ -26,11 +26,9 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
 
                     return;
                 }
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             }, prop => {
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             });
@@ -45,7 +43,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
                 }
             }, parseAssertElemPropKey => {
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/pseudo-1.toml
+++ b/tests/api-output/parseAssertPropertyFalse/pseudo-1.toml
@@ -25,11 +25,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -44,7 +42,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/pseudo-2.toml
+++ b/tests/api-output/parseAssertPropertyFalse/pseudo-2.toml
@@ -26,11 +26,9 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
 
                     return;
                 }
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             }, prop => {
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             });
@@ -45,7 +43,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
                 }
             }, parseAssertElemPropKey => {
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/pseudo-3.toml
+++ b/tests/api-output/parseAssertPropertyFalse/pseudo-3.toml
@@ -25,11 +25,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -44,7 +42,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/pseudo-4.toml
+++ b/tests/api-output/parseAssertPropertyFalse/pseudo-4.toml
@@ -26,11 +26,9 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
 
                     return;
                 }
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             }, prop => {
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             });
@@ -45,7 +43,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
                 }
             }, parseAssertElemPropKey => {
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/pseudo-5.toml
+++ b/tests/api-output/parseAssertPropertyFalse/pseudo-5.toml
@@ -25,11 +25,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -44,7 +42,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/pseudo-6.toml
+++ b/tests/api-output/parseAssertPropertyFalse/pseudo-6.toml
@@ -26,11 +26,9 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
 
                     return;
                 }
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             }, prop => {
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             });
@@ -45,7 +43,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
                 }
             }, parseAssertElemPropKey => {
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/undef-1.toml
+++ b/tests/api-output/parseAssertPropertyFalse/undef-1.toml
@@ -25,11 +25,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -44,7 +42,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/undef-2.toml
+++ b/tests/api-output/parseAssertPropertyFalse/undef-2.toml
@@ -25,11 +25,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -44,7 +42,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/undef-3.toml
+++ b/tests/api-output/parseAssertPropertyFalse/undef-3.toml
@@ -25,11 +25,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -44,7 +42,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/undef-4.toml
+++ b/tests/api-output/parseAssertPropertyFalse/undef-4.toml
@@ -25,11 +25,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -44,7 +42,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/xpath-1.toml
+++ b/tests/api-output/parseAssertPropertyFalse/xpath-1.toml
@@ -26,11 +26,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -45,7 +43,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/xpath-1.toml
+++ b/tests/api-output/parseAssertPropertyFalse/xpath-1.toml
@@ -1,3 +1,59 @@
 instructions = [
+  """let parseAssertElemProp = await page.$x(\"//a\");
+if (parseAssertElemProp.length === 0) { throw 'XPath \"//a\" not found'; }
+parseAssertElemProp = parseAssertElemProp[0];
+await page.evaluate(e => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertElemPropDict = [];
+    const undefProps = [];
+    for (const prop of undefProps) {
+        checkObjectPaths(e, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertElemPropKey, parseAssertElemPropValue] of parseAssertElemPropDict) {
+        checkObjectPaths(e, parseAssertElemPropKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop === parseAssertElemPropValue) {
+                nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
+            }
+        }, parseAssertElemPropKey => {
+});
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened (for XPath `//a`): [\" + props + \"]\";
+    }
+}, parseAssertElemProp);""",
 ]
 wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertPropertyFalse/xpath-2.toml
+++ b/tests/api-output/parseAssertPropertyFalse/xpath-2.toml
@@ -26,11 +26,9 @@ await page.evaluate(e => {
 
                 return;
             }
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         }, prop => {
-
             const p = prop.map(p => `\"${p}\"`).join('.');
             nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
         });
@@ -45,7 +43,7 @@ await page.evaluate(e => {
                 nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
             }
         }, parseAssertElemPropKey => {
-});
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertPropertyFalse/xpath-3.toml
+++ b/tests/api-output/parseAssertPropertyFalse/xpath-3.toml
@@ -26,11 +26,9 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
 
                     return;
                 }
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             }, prop => {
-
                 const p = prop.map(p => `\"${p}\"`).join('.');
                 nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
             });
@@ -45,7 +43,7 @@ for (let i = 0, len = parseAssertElemProp.length; i < len; ++i) {
                     nonMatchingProps.push(\"assert didn't fail for property `\" + parseAssertElemPropKey.map(p => `\"${p}\"`).join('.') + \"` (`\" + prop + \"`)\");
                 }
             }, parseAssertElemPropKey => {
-    });
+            });
         }
         if (nonMatchingProps.length !== 0) {
             const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertWindowProperty/basic-1.toml
+++ b/tests/api-output/parseAssertWindowProperty/basic-1.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown window property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp !== parseAssertDictPropValue) {
-            nonMatchingProps.push(\"expected `\" + parseAssertDictPropValue + \"` for window property `\" + parseAssertDictPropKey + \"`, found `\" + parseAssertDictProp + \"`\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (prop !== parseAssertObjValue) {
+                nonMatchingProps.push(\"expected `\" + parseAssertObjValue + \"` for window property `\" + parseAssertObjKey + \"`, found `\" + prop + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -26,4 +50,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowProperty/basic-2.toml
+++ b/tests/api-output/parseAssertWindowProperty/basic-2.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown window property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp !== parseAssertDictPropValue) {
-            nonMatchingProps.push(\"expected `\" + parseAssertDictPropValue + \"` for window property `\" + parseAssertDictPropKey + \"`, found `\" + parseAssertDictProp + \"`\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (prop !== parseAssertObjValue) {
+                nonMatchingProps.push(\"expected `\" + parseAssertObjValue + \"` for window property `\" + parseAssertObjKey + \"`, found `\" + prop + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -26,4 +50,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowProperty/extra-1.toml
+++ b/tests/api-output/parseAssertWindowProperty/extra-1.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown window property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.includes(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't contain `\" + parseAssertDictPropValue + \"` (for CONTAINS check)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.includes(parseAssertObjValue)) {
+                nonMatchingProps.push(\"window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't contain `\" + parseAssertObjValue + \"` (for CONTAINS check)\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -26,4 +50,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowProperty/extra-2.toml
+++ b/tests/api-output/parseAssertWindowProperty/extra-2.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown window property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't start with `\" + parseAssertDictPropValue + \"` (for STARTS_WITH check)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't start with `\" + parseAssertObjValue + \"` (for STARTS_WITH check)\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -26,4 +50,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowProperty/extra-3.toml
+++ b/tests/api-output/parseAssertWindowProperty/extra-3.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown window property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.endsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't end with `\" + parseAssertDictPropValue + \"`\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.endsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't end with `\" + parseAssertObjValue + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -26,4 +50,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowProperty/extra-4.toml
+++ b/tests/api-output/parseAssertWindowProperty/extra-4.toml
@@ -1,26 +1,50 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown window property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't start with `\" + parseAssertDictPropValue + \"` (for STARTS_WITH check)\");
-        }
-        if (!parseAssertDictProp.endsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't end with `\" + parseAssertDictPropValue + \"`\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't start with `\" + parseAssertObjValue + \"` (for STARTS_WITH check)\");
+            }
+            if (!prop.endsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't end with `\" + parseAssertObjValue + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -29,4 +53,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowProperty/extra-5.toml
+++ b/tests/api-output/parseAssertWindowProperty/extra-5.toml
@@ -1,32 +1,56 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-            continue;
-        }
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown window property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't start with `\" + parseAssertDictPropValue + \"` (for STARTS_WITH check)\");
-        }
-        const tmpNb = parseFloat(parseAssertDictProp);
-        const tmpNb2 = parseFloat(parseAssertDictPropValue);
-        if (Number.isNaN(tmpNb)) {
-            nonMatchingProps.push('window property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is NaN (for NEAR check)');
-        } else if (Number.isNaN(tmpNb2)) {
-            nonMatchingProps.push('provided value for `' + parseAssertDictPropKey + '` is NaN (for NEAR check)');
-        } else if (Math.abs(parseAssertDictProp - parseAssertDictPropValue) > 1) {
-            nonMatchingProps.push('window property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is not within 1 of `' + parseAssertDictPropValue + '` (for NEAR check)');
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't start with `\" + parseAssertObjValue + \"` (for STARTS_WITH check)\");
+            }
+            const tmpNb = parseFloat(prop);
+            const tmpNb2 = parseFloat(parseAssertObjValue);
+            if (Number.isNaN(tmpNb)) {
+                nonMatchingProps.push('window property `' + parseAssertObjKey + '` (`' + prop + '`) is NaN (for NEAR check)');
+            } else if (Number.isNaN(tmpNb2)) {
+                nonMatchingProps.push('provided value for `' + parseAssertObjKey + '` is NaN (for NEAR check)');
+            } else if (Math.abs(prop - parseAssertObjValue) > 1) {
+                nonMatchingProps.push('window property `' + parseAssertObjKey + '` (`' + prop + '`) is not within 1 of `' + parseAssertObjValue + '` (for NEAR check)');
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -35,4 +59,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowProperty/null-2.toml
+++ b/tests/api-output/parseAssertWindowProperty/null-2.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown window property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp !== parseAssertDictPropValue) {
-            nonMatchingProps.push(\"expected `\" + parseAssertDictPropValue + \"` for window property `\" + parseAssertDictPropKey + \"`, found `\" + parseAssertDictProp + \"`\");
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (prop !== parseAssertObjValue) {
+                nonMatchingProps.push(\"expected `\" + parseAssertObjValue + \"` for window property `\" + parseAssertObjKey + \"`, found `\" + prop + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -26,4 +50,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowProperty/null-3.toml
+++ b/tests/api-output/parseAssertWindowProperty/null-3.toml
@@ -1,23 +1,47 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown window property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.endsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't end with `\" + parseAssertDictPropValue + \"`\");
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.endsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't end with `\" + parseAssertObjValue + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertWindowProperty/null-4.toml
+++ b/tests/api-output/parseAssertWindowProperty/null-4.toml
@@ -1,32 +1,56 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown window property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't start with `\" + parseAssertDictPropValue + \"` (for STARTS_WITH check)\");
-        }
-        const tmpNb = parseFloat(parseAssertDictProp);
-        const tmpNb2 = parseFloat(parseAssertDictPropValue);
-        if (Number.isNaN(tmpNb)) {
-            nonMatchingProps.push('window property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is NaN (for NEAR check)');
-        } else if (Number.isNaN(tmpNb2)) {
-            nonMatchingProps.push('provided value for `' + parseAssertDictPropKey + '` is NaN (for NEAR check)');
-        } else if (Math.abs(parseAssertDictProp - parseAssertDictPropValue) > 1) {
-            nonMatchingProps.push('window property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is not within 1 of `' + parseAssertDictPropValue + '` (for NEAR check)');
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't start with `\" + parseAssertObjValue + \"` (for STARTS_WITH check)\");
+            }
+            const tmpNb = parseFloat(prop);
+            const tmpNb2 = parseFloat(parseAssertObjValue);
+            if (Number.isNaN(tmpNb)) {
+                nonMatchingProps.push('window property `' + parseAssertObjKey + '` (`' + prop + '`) is NaN (for NEAR check)');
+            } else if (Number.isNaN(tmpNb2)) {
+                nonMatchingProps.push('provided value for `' + parseAssertObjKey + '` is NaN (for NEAR check)');
+            } else if (Math.abs(prop - parseAssertObjValue) > 1) {
+                nonMatchingProps.push('window property `' + parseAssertObjKey + '` (`' + prop + '`) is not within 1 of `' + parseAssertObjValue + '` (for NEAR check)');
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertWindowProperty/null-5.toml
+++ b/tests/api-output/parseAssertWindowProperty/null-5.toml
@@ -1,32 +1,56 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"b\":\"12\"};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            nonMatchingProps.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            nonMatchingProps.push('Unknown window property `' + parseAssertDictPropKey + '`');
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (!parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) doesn't start with `\" + parseAssertDictPropValue + \"` (for STARTS_WITH check)\");
-        }
-        const tmpNb = parseFloat(parseAssertDictProp);
-        const tmpNb2 = parseFloat(parseAssertDictPropValue);
-        if (Number.isNaN(tmpNb)) {
-            nonMatchingProps.push('window property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is NaN (for NEAR check)');
-        } else if (Number.isNaN(tmpNb2)) {
-            nonMatchingProps.push('provided value for `' + parseAssertDictPropKey + '` is NaN (for NEAR check)');
-        } else if (Math.abs(parseAssertDictProp - parseAssertDictPropValue) > 1) {
-            nonMatchingProps.push('window property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is not within 1 of `' + parseAssertDictPropValue + '` (for NEAR check)');
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [[[\"b\"],\"12\"]];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't start with `\" + parseAssertObjValue + \"` (for STARTS_WITH check)\");
+            }
+            const tmpNb = parseFloat(prop);
+            const tmpNb2 = parseFloat(parseAssertObjValue);
+            if (Number.isNaN(tmpNb)) {
+                nonMatchingProps.push('window property `' + parseAssertObjKey + '` (`' + prop + '`) is NaN (for NEAR check)');
+            } else if (Number.isNaN(tmpNb2)) {
+                nonMatchingProps.push('provided value for `' + parseAssertObjKey + '` is NaN (for NEAR check)');
+            } else if (Math.abs(prop - parseAssertObjValue) > 1) {
+                nonMatchingProps.push('window property `' + parseAssertObjKey + '` (`' + prop + '`) is not within 1 of `' + parseAssertObjValue + '` (for NEAR check)');
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertWindowProperty/object-path-1.toml
+++ b/tests/api-output/parseAssertWindowProperty/object-path-1.toml
@@ -1,0 +1,55 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [[[\"a\",\"b\"],\"b\"]];
+    const undefProps = [];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (prop !== parseAssertObjValue) {
+                nonMatchingProps.push(\"expected `\" + parseAssertObjValue + \"` for window property `\" + parseAssertObjKey + \"`, found `\" + prop + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertWindowProperty/object-path-2.toml
+++ b/tests/api-output/parseAssertWindowProperty/object-path-2.toml
@@ -1,0 +1,55 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [[[\"a\",\"b\"],\"b\"]];
+    const undefProps = [];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.includes(parseAssertObjValue)) {
+                nonMatchingProps.push(\"window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't contain `\" + parseAssertObjValue + \"` (for CONTAINS check)\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertWindowProperty/object-path-3.toml
+++ b/tests/api-output/parseAssertWindowProperty/object-path-3.toml
@@ -1,0 +1,55 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\",\"b\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (prop !== parseAssertObjValue) {
+                nonMatchingProps.push(\"expected `\" + parseAssertObjValue + \"` for window property `\" + parseAssertObjKey + \"`, found `\" + prop + \"`\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertWindowProperty/object-path-4.toml
+++ b/tests/api-output/parseAssertWindowProperty/object-path-4.toml
@@ -1,0 +1,56 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\",\"b\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+                const p = prop.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                return;
+            }
+        }, prop => {
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push('Unknown window property `' + p + '`');
+                return;
+            }
+            const prop = String(val);
+            if (!prop.includes(parseAssertObjValue)) {
+                nonMatchingProps.push(\"window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) doesn't contain `\" + parseAssertObjValue + \"` (for CONTAINS check)\");
+            }
+        }, parseAssertObjKey => {
+            const p = parseAssertObjKey.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push('Unknown window property `' + p + '`');
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+  """Special checks (CONTAINS) will be ignored for `null`""",
+]
+checkResult = true

--- a/tests/api-output/parseAssertWindowPropertyFalse/basic-1.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/basic-1.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp === parseAssertDictPropValue) {
-            nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop === parseAssertObjValue) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -25,4 +49,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowPropertyFalse/basic-2.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/basic-2.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp === parseAssertDictPropValue) {
-            nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop === parseAssertObjValue) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -25,4 +49,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowPropertyFalse/extra-1.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/extra-1.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp.includes(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for CONTAINS check)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.includes(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for CONTAINS check)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -25,4 +49,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowPropertyFalse/extra-2.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/extra-2.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for STARTS_WITH check)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -25,4 +49,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowPropertyFalse/extra-3.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/extra-3.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp.endsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for ENDS_WITH check)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.endsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for ENDS_WITH check)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -25,4 +49,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowPropertyFalse/extra-4.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/extra-4.toml
@@ -1,25 +1,49 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for STARTS_WITH check)\");
-        }
-        if (parseAssertDictProp.endsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for ENDS_WITH check)\");
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
+            }
+            if (prop.endsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for ENDS_WITH check)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -28,4 +52,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowPropertyFalse/extra-5.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/extra-5.toml
@@ -1,31 +1,55 @@
 instructions = [
   """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
     const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"a\":\"b\"};
+    const parseAssertObjDict = [[[\"a\"],\"b\"]];
     const undefProps = [];
     for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            continue;
-        }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for STARTS_WITH check)\");
-        }
-        const tmpNb = parseFloat(parseAssertDictProp);
-        const tmpNb2 = parseFloat(parseAssertDictPropValue);
-        if (Number.isNaN(tmpNb)) {
-            nonMatchingProps.push('window property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is NaN (for NEAR check)');
-        } else if (Number.isNaN(tmpNb2)) {
-            nonMatchingProps.push('provided value for `' + parseAssertDictPropKey + '` is NaN (for NEAR check)');
-        } else if (Math.abs(tmpNb - tmpNb2) <= 1) {
-            nonMatchingProps.push('window property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is within 1 of `' + parseAssertDictPropValue + '` (for NEAR check)');
-        }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
+            }
+            const tmpNb = parseFloat(prop);
+            const tmpNb2 = parseFloat(parseAssertObjValue);
+            if (Number.isNaN(tmpNb)) {
+                nonMatchingProps.push('window property `' + parseAssertObjKey + '` (`' + prop + '`) is NaN (for NEAR check)');
+            } else if (Number.isNaN(tmpNb2)) {
+                nonMatchingProps.push('provided value for `' + parseAssertObjKey + '` is NaN (for NEAR check)');
+            } else if (Math.abs(tmpNb - tmpNb2) <= 1) {
+                nonMatchingProps.push('window property `' + parseAssertObjKey + '` (`' + prop + '`) is within 1 of `' + parseAssertObjValue + '` (for NEAR check)');
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -34,4 +58,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowPropertyFalse/null-2.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/null-2.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp === parseAssertDictPropValue) {
-            nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`)\");
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop === parseAssertObjValue) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");
@@ -25,4 +49,6 @@ instructions = [
 });""",
 ]
 wait = false
+warnings = [
+]
 checkResult = true

--- a/tests/api-output/parseAssertWindowPropertyFalse/null-3.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/null-3.toml
@@ -1,22 +1,46 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp.endsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for ENDS_WITH check)\");
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.endsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for ENDS_WITH check)\");
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertWindowPropertyFalse/null-4.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/null-4.toml
@@ -1,31 +1,55 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for STARTS_WITH check)\");
-        }
-        const tmpNb = parseFloat(parseAssertDictProp);
-        const tmpNb2 = parseFloat(parseAssertDictPropValue);
-        if (Number.isNaN(tmpNb)) {
-            nonMatchingProps.push('window property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is NaN (for NEAR check)');
-        } else if (Number.isNaN(tmpNb2)) {
-            nonMatchingProps.push('provided value for `' + parseAssertDictPropKey + '` is NaN (for NEAR check)');
-        } else if (Math.abs(tmpNb - tmpNb2) <= 1) {
-            nonMatchingProps.push('window property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is within 1 of `' + parseAssertDictPropValue + '` (for NEAR check)');
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
+            }
+            const tmpNb = parseFloat(prop);
+            const tmpNb2 = parseFloat(parseAssertObjValue);
+            if (Number.isNaN(tmpNb)) {
+                nonMatchingProps.push('window property `' + parseAssertObjKey + '` (`' + prop + '`) is NaN (for NEAR check)');
+            } else if (Number.isNaN(tmpNb2)) {
+                nonMatchingProps.push('provided value for `' + parseAssertObjKey + '` is NaN (for NEAR check)');
+            } else if (Math.abs(tmpNb - tmpNb2) <= 1) {
+                nonMatchingProps.push('window property `' + parseAssertObjKey + '` (`' + prop + '`) is within 1 of `' + parseAssertObjValue + '` (for NEAR check)');
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertWindowPropertyFalse/null-5.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/null-5.toml
@@ -1,31 +1,55 @@
 instructions = [
   """await page.evaluate(() => {
-    const nonMatchingProps = [];
-    const parseAssertDictPropDict = {\"b\":\"12\"};
-    const undefProps = [\"a\"];
-    for (const prop of undefProps) {
-        if (window[prop] !== undefined && window[prop] !== null) {
-            continue;
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
         }
-        nonMatchingProps.push(\"Property named `\" + prop + \"` doesn't exist\");
+        callback(object);
     }
-    for (const [parseAssertDictPropKey, parseAssertDictPropValue] of Object.entries(parseAssertDictPropDict)) {
-        if (window[parseAssertDictPropKey] === undefined) {
-            continue;
-        }
-        const parseAssertDictProp = String(window[parseAssertDictPropKey]);
-        if (parseAssertDictProp.startsWith(parseAssertDictPropValue)) {
-            nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertDictPropKey + \"` (`\" + parseAssertDictProp + \"`) (for STARTS_WITH check)\");
-        }
-        const tmpNb = parseFloat(parseAssertDictProp);
-        const tmpNb2 = parseFloat(parseAssertDictPropValue);
-        if (Number.isNaN(tmpNb)) {
-            nonMatchingProps.push('window property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is NaN (for NEAR check)');
-        } else if (Number.isNaN(tmpNb2)) {
-            nonMatchingProps.push('provided value for `' + parseAssertDictPropKey + '` is NaN (for NEAR check)');
-        } else if (Math.abs(tmpNb - tmpNb2) <= 1) {
-            nonMatchingProps.push('window property `' + parseAssertDictPropKey + '` (`' + parseAssertDictProp + '`) is within 1 of `' + parseAssertDictPropValue + '` (for NEAR check)');
-        }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [[[\"b\"],\"12\"]];
+    const undefProps = [[\"a\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.startsWith(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for STARTS_WITH check)\");
+            }
+            const tmpNb = parseFloat(prop);
+            const tmpNb2 = parseFloat(parseAssertObjValue);
+            if (Number.isNaN(tmpNb)) {
+                nonMatchingProps.push('window property `' + parseAssertObjKey + '` (`' + prop + '`) is NaN (for NEAR check)');
+            } else if (Number.isNaN(tmpNb2)) {
+                nonMatchingProps.push('provided value for `' + parseAssertObjKey + '` is NaN (for NEAR check)');
+            } else if (Math.abs(tmpNb - tmpNb2) <= 1) {
+                nonMatchingProps.push('window property `' + parseAssertObjKey + '` (`' + prop + '`) is within 1 of `' + parseAssertObjValue + '` (for NEAR check)');
+            }
+        }, parseAssertObjKey => {
+        });
     }
     if (nonMatchingProps.length !== 0) {
         const props = nonMatchingProps.join(\"; \");

--- a/tests/api-output/parseAssertWindowPropertyFalse/object-path-1.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/object-path-1.toml
@@ -1,0 +1,54 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [[[\"a\",\"b\"],\"b\"]];
+    const undefProps = [];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop === parseAssertObjValue) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`)\");
+            }
+        }, parseAssertObjKey => {
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertWindowPropertyFalse/object-path-2.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/object-path-2.toml
@@ -1,0 +1,54 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [[[\"a\",\"b\"],\"b\"]];
+    const undefProps = [];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.includes(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for CONTAINS check)\");
+            }
+        }, parseAssertObjKey => {
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertWindowPropertyFalse/object-path-3.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/object-path-3.toml
@@ -1,0 +1,54 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\",\"b\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop === parseAssertObjValue) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`)\");
+            }
+        }, parseAssertObjKey => {
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+]
+checkResult = true

--- a/tests/api-output/parseAssertWindowPropertyFalse/object-path-4.toml
+++ b/tests/api-output/parseAssertWindowPropertyFalse/object-path-4.toml
@@ -1,0 +1,55 @@
+instructions = [
+  """await page.evaluate(() => {
+    function checkObjectPaths(object, path, callback, notFoundCallback) {
+        const found = [];
+
+        for (const subPath of path) {
+            found.push(subPath);
+            if (object === undefined || object === null) {
+                notFoundCallback(found);
+                return;
+            }
+            object = object[subPath];
+        }
+        callback(object);
+    }
+
+    const nonMatchingProps = [];
+    const parseAssertObjDict = [];
+    const undefProps = [[\"a\",\"b\"]];
+    for (const prop of undefProps) {
+        checkObjectPaths(window, prop, val => {
+            if (val !== undefined && val !== null) {
+
+                return;
+            }
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        }, prop => {
+            const p = prop.map(p => `\"${p}\"`).join('.');
+            nonMatchingProps.push(\"Property named `\" + p + \"` doesn't exist\");
+        });
+    }
+    for (const [parseAssertObjKey, parseAssertObjValue] of parseAssertObjDict) {
+        checkObjectPaths(window, parseAssertObjKey, val => {
+            if (val === undefined && val === null) {
+                return;
+            }
+            const prop = String(val);
+            if (prop.includes(parseAssertObjValue)) {
+                nonMatchingProps.push(\"assert didn't fail for window property `\" + parseAssertObjKey + \"` (`\" + prop + \"`) (for CONTAINS check)\");
+            }
+        }, parseAssertObjKey => {
+        });
+    }
+    if (nonMatchingProps.length !== 0) {
+        const props = nonMatchingProps.join(\"; \");
+        throw \"The following errors happened: [\" + props + \"]\";
+    }
+});""",
+]
+wait = false
+warnings = [
+  """Special checks (CONTAINS) will be ignored for `null`""",
+]
+checkResult = true

--- a/tests/ui/assert-null.output
+++ b/tests/ui/assert-null.output
@@ -11,8 +11,8 @@ assert-null... FAILED
 [ERROR] `tests/ui/assert-null.goml` line 11: Error: Evaluation failed: The following errors happened (for selector `header`): [Attribute named `whatever` doesn't exist]: for command `assert-attribute-false: ("header", {"whatever": null})`
 [ERROR] `tests/ui/assert-null.goml` line 32: Error: Evaluation failed: The following errors happened (for selector `header`): [Property named `"bgColor"` doesn't exist]: for command `assert-property-false: ("header", {"bgColor": null})`
 [ERROR] `tests/ui/assert-null.goml` line 34: Error: Evaluation failed: The following errors happened (for selector `header`): [Property named `"yolo"` doesn't exist]: for command `assert-property-false: ("header", {"yolo": null})`
-[ERROR] `tests/ui/assert-null.goml` line 54: Error: Evaluation failed: The following errors happened: [Expected property `bgColor` to not exist, found: ``]: for command `assert-document-property: {"bgColor": null}`
-[ERROR] `tests/ui/assert-null.goml` line 57: Error: Evaluation failed: The following errors happened: [Property named `yolo` doesn't exist]: for command `assert-document-property-false: {"yolo": null}`
+[ERROR] `tests/ui/assert-null.goml` line 54: Error: Evaluation failed: The following errors happened: [Expected property `"bgColor"` to not exist, found: ``]: for command `assert-document-property: {"bgColor": null}`
+[ERROR] `tests/ui/assert-null.goml` line 57: Error: Evaluation failed: The following errors happened: [Property named `"yolo"` doesn't exist]: for command `assert-document-property-false: {"yolo": null}`
 
 
 <= doc-ui tests done: 0 succeeded, 1 failed

--- a/tests/ui/object-path.goml
+++ b/tests/ui/object-path.goml
@@ -1,5 +1,10 @@
 screenshot-comparison: false
 go-to: "file://" + |CURRENT_DIR| + "/" + |DOC_PATH| + "/elements.html"
+
+//
+// assert-property
+//
+
 // Should fail.
 assert-property: ("body", {"firstElementChild"."innerText": "Another page", "offsetWidth": "200"})
 // Should not fail.
@@ -20,3 +25,77 @@ assert-property-false: ("body", {"firstElementChild"."innerText": "Another page!
 assert-property-false: ("body", {"firstElementChild"."innerText": null, "offsetWidth": null})
 // Should fail.
 assert-property-false: ("body", {"firstElementChild"."innerTe": null, "offsetWidth2": null})
+
+//
+// assert-document-property
+//
+
+// Should fail.
+assert-document-property: {
+    "body"."firstElementChild"."innerText": "Another page",
+    "offsetWidth": "200",
+}
+// Should not fail.
+assert-document-property: {
+    "body"."firstElementChild"."innerText": "Another page!",
+    "offsetWidth": "1000",
+}
+// Should fail (check that trying to access "whatever" from "offsetWidth", a number, should not crash).
+assert-document-property: { "body"."offsetWidth"."whatever": 2 }
+// Should not fail.
+assert-document-property: { "body"."firstElementChild"."innerTe": null, "offsetWidth2": null}
+
+// Should not fail.
+assert-document-property-false: {
+    "body"."firstElementChild"."innerText": "Another page",
+    "offsetWidth": "200",
+}
+// Should fail.
+assert-document-property-false: {
+    "body"."firstElementChild"."innerText": "Another page!",
+    "offsetWidth": "1000",
+}
+// Should not fail.
+assert-document-property-false: { "body"."offsetWidth"."whatever": 2 }
+// Should fail.
+assert-document-property-false: { "body"."firstElementChild"."innerTe": null, "offsetWidth2": null}
+
+//
+// assert-window-property
+//
+
+// Should fail.
+assert-window-property: {
+    "document"."body"."firstElementChild"."innerText": "Another page",
+    "innerWidth": "200",
+}
+// Should not fail.
+assert-window-property: {
+    "document"."body"."firstElementChild"."innerText": "Another page!",
+    "innerWidth": "1000",
+}
+// Should fail (check that trying to access "whatever" from "offsetWidth", a number, should not crash).
+assert-window-property: { "document"."body"."offsetWidth"."whatever": 2 }
+// Should not fail.
+assert-window-property: {
+    "document"."body"."firstElementChild"."innerTe": null,
+    "innerWidth2": null,
+}
+
+// Should not fail.
+assert-window-property-false: {
+    "document"."body"."firstElementChild"."innerText": "Another page",
+    "innerWidth": "200",
+}
+// Should fail.
+assert-window-property-false: {
+    "document"."body"."firstElementChild"."innerText": "Another page!",
+    "innerWidth": "1000",
+}
+// Should not fail.
+assert-window-property-false: { "document"."body"."offsetWidth"."whatever": 2 }
+// Should fail.
+assert-window-property-false: {
+    "document"."body"."firstElementChild"."innerTe": null,
+    "offsetWidth2": null,
+}

--- a/tests/ui/object-path.output
+++ b/tests/ui/object-path.output
@@ -1,13 +1,40 @@
 => Starting doc-ui tests...
 
 object-path... FAILED
-[ERROR] `tests/ui/object-path.goml` line 4: Error: Evaluation failed: The following errors happened (for selector `body`): [expected `Another page` for property `"firstElementChild"."innerText"`, found `Another page!`; expected `200` for property `"offsetWidth"`, found `1000`]: for command `assert-property: ("body", {"firstElementChild"."innerText": "Another page", "offsetWidth": "200"})`
-[ERROR] `tests/ui/object-path.goml` line 8: Error: Evaluation failed: The following errors happened (for selector `body`): [expected `2` for property `"offsetWidth"."whatever"`, found `undefined`]: for command `assert-property: (
+[ERROR] `tests/ui/object-path.goml` line 9: Error: Evaluation failed: The following errors happened (for selector `body`): [expected `Another page` for property `"firstElementChild"."innerText"`, found `Another page!`; expected `200` for property `"offsetWidth"`, found `1000`]: for command `assert-property: ("body", {"firstElementChild"."innerText": "Another page", "offsetWidth": "200"})`
+[ERROR] `tests/ui/object-path.goml` line 13: Error: Evaluation failed: The following errors happened (for selector `body`): [expected `2` for property `"offsetWidth"."whatever"`, found `undefined`]: for command `assert-property: (
     "body",
     {"offsetWidth"."whatever": 2},
 )`
-[ERROR] `tests/ui/object-path.goml` line 18: Error: Evaluation failed: The following errors happened (for selector `body`): [assert didn't fail for property `"firstElementChild"."innerText"` (`Another page!`); assert didn't fail for property `"offsetWidth"` (`1000`)]: for command `assert-property-false: ("body", {"firstElementChild"."innerText": "Another page!", "offsetWidth": "1000"})`
-[ERROR] `tests/ui/object-path.goml` line 22: Error: Evaluation failed: The following errors happened (for selector `body`): [Property named `"firstElementChild"."innerTe"` doesn't exist; Property named `"offsetWidth2"` doesn't exist]: for command `assert-property-false: ("body", {"firstElementChild"."innerTe": null, "offsetWidth2": null})`
+[ERROR] `tests/ui/object-path.goml` line 23: Error: Evaluation failed: The following errors happened (for selector `body`): [assert didn't fail for property `"firstElementChild"."innerText"` (`Another page!`); assert didn't fail for property `"offsetWidth"` (`1000`)]: for command `assert-property-false: ("body", {"firstElementChild"."innerText": "Another page!", "offsetWidth": "1000"})`
+[ERROR] `tests/ui/object-path.goml` line 27: Error: Evaluation failed: The following errors happened (for selector `body`): [Property named `"firstElementChild"."innerTe"` doesn't exist; Property named `"offsetWidth2"` doesn't exist]: for command `assert-property-false: ("body", {"firstElementChild"."innerTe": null, "offsetWidth2": null})`
+[ERROR] `tests/ui/object-path.goml` line 34: Error: Evaluation failed: The following errors happened: [expected `Another page` for document property `body,firstElementChild,innerText`, found `Another page!`; expected `200` for document property `offsetWidth`, found `undefined`]: for command `assert-document-property: {
+    "body"."firstElementChild"."innerText": "Another page",
+    "offsetWidth": "200",
+}`
+[ERROR] `tests/ui/object-path.goml` line 39: Error: Evaluation failed: The following errors happened: [expected `1000` for document property `offsetWidth`, found `undefined`]: for command `assert-document-property: {
+    "body"."firstElementChild"."innerText": "Another page!",
+    "offsetWidth": "1000",
+}`
+[ERROR] `tests/ui/object-path.goml` line 44: Error: Evaluation failed: The following errors happened: [expected `2` for document property `body,offsetWidth,whatever`, found `undefined`]: for command `assert-document-property: { "body"."offsetWidth"."whatever": 2 }`
+[ERROR] `tests/ui/object-path.goml` line 54: Error: Evaluation failed: The following errors happened: [assert didn't fail for document property `body,firstElementChild,innerText` (`Another page!`)]: for command `assert-document-property-false: {
+    "body"."firstElementChild"."innerText": "Another page!",
+    "offsetWidth": "1000",
+}`
+[ERROR] `tests/ui/object-path.goml` line 61: Error: Evaluation failed: The following errors happened: [Property named `"body"."firstElementChild"."innerTe"` doesn't exist; Property named `"offsetWidth2"` doesn't exist]: for command `assert-document-property-false: { "body"."firstElementChild"."innerTe": null, "offsetWidth2": null}`
+[ERROR] `tests/ui/object-path.goml` line 68: Error: Evaluation failed: The following errors happened: [expected `Another page` for window property `document,body,firstElementChild,innerText`, found `Another page!`; expected `200` for window property `innerWidth`, found `1000`]: for command `assert-window-property: {
+    "document"."body"."firstElementChild"."innerText": "Another page",
+    "innerWidth": "200",
+}`
+[ERROR] `tests/ui/object-path.goml` line 78: Error: Evaluation failed: The following errors happened: [expected `2` for window property `document,body,offsetWidth,whatever`, found `undefined`]: for command `assert-window-property: { "document"."body"."offsetWidth"."whatever": 2 }`
+[ERROR] `tests/ui/object-path.goml` line 91: Error: Evaluation failed: The following errors happened: [assert didn't fail for window property `document,body,firstElementChild,innerText` (`Another page!`); assert didn't fail for window property `innerWidth` (`1000`)]: for command `assert-window-property-false: {
+    "document"."body"."firstElementChild"."innerText": "Another page!",
+    "innerWidth": "1000",
+}`
+[ERROR] `tests/ui/object-path.goml` line 98: Error: Evaluation failed: The following errors happened: [Property named `"document"."body"."firstElementChild"."innerTe"` doesn't exist; Property named `"offsetWidth2"` doesn't exist]: for command `assert-window-property-false: {
+    "document"."body"."firstElementChild"."innerTe": null,
+    "offsetWidth2": null,
+}`
 
 
 <= doc-ui tests done: 0 succeeded, 1 failed

--- a/tests/ui/parser-errors.output
+++ b/tests/ui/parser-errors.output
@@ -3,7 +3,7 @@
 parser-errors... FAILED
 Syntax errors:
 `tests/ui/parser-errors.goml` line 2: expected `,` or `)` after `foo`, found `{1: 2}`
-`tests/ui/parser-errors.goml` line 2: only strings can be used as keys in JSON dict, found a number (`1`)
+`tests/ui/parser-errors.goml` line 2: only strings and object paths can be used as keys in JSON dict, found a number (`1`)
 `tests/ui/parser-errors.goml` line 3: all array's elements must be of the same kind: expected array of `string` (because the first element is of this kind), found `number` at position 1
 `tests/ui/parser-errors.goml` line 3: expected `,` or `]` after `"a"`, found `|b`
 `tests/ui/parser-errors.goml` line 3: unexpected character `]` after `|b`

--- a/tools/api.js
+++ b/tools/api.js
@@ -265,6 +265,12 @@ function checkAssertObjProperty(x, func) {
     func('({"a": null}, ENDS_WITH)', 'null-3');
     func('({"a": null}, [STARTS_WITH, NEAR])', 'null-4');
     func('({"a": null, "b": "12"}, [STARTS_WITH, NEAR])', 'null-5');
+
+    // object-path
+    func('{"a"."b": "b"}', 'object-path-1');
+    func('({"a"."b": "b"}, CONTAINS)', 'object-path-2');
+    func('({"a"."b": null})', 'object-path-3');
+    func('({"a"."b": null}, CONTAINS)', 'object-path-4');
 }
 
 function checkAssertVariable(x, func) {

--- a/tools/parser.js
+++ b/tools/parser.js
@@ -1063,12 +1063,14 @@ function checkJson(x) {
     let p = new Parser('{1: 2}');
     p.parse();
     x.assert(
-        p.errors[0].message, 'only strings can be used as keys in JSON dict, found a number (`1`)');
+        p.errors[0].message,
+        'only strings and object paths can be used as keys in JSON dict, found a number (`1`)',
+    );
     x.assert(p.elems.length, 1);
     x.assert(p.elems[0].kind, 'json');
     x.assert(
         p.elems[0].error,
-        'only strings can be used as keys in JSON dict, found a number (`1`)',
+        'only strings and object paths can be used as keys in JSON dict, found a number (`1`)',
     );
     x.assert(p.elems[0].getErrorText(), '{1: 2}');
     x.assert(p.elems[0].getRaw().length, 1);
@@ -1082,12 +1084,13 @@ function checkJson(x) {
     p.parse();
     x.assert(
         p.errors[0].message,
-        'only strings can be used as keys in JSON dict, found a number (`-1`)');
+        'only strings and object paths can be used as keys in JSON dict, found a number (`-1`)',
+    );
     x.assert(p.elems.length, 1);
     x.assert(p.elems[0].kind, 'json');
     x.assert(
         p.elems[0].error,
-        'only strings can be used as keys in JSON dict, found a number (`-1`)',
+        'only strings and object paths can be used as keys in JSON dict, found a number (`-1`)',
     );
     x.assert(p.elems[0].getErrorText(), '{-1: 2}');
     x.assert(p.elems[0].getRaw().length, 1);
@@ -1101,12 +1104,13 @@ function checkJson(x) {
     p.parse();
     x.assert(
         p.errors[0].message,
-        'only strings can be used as keys in JSON dict, found a number (`-1.2`)');
+        'only strings and object paths can be used as keys in JSON dict, found a number (`-1.2`)',
+    );
     x.assert(p.elems.length, 1);
     x.assert(p.elems[0].kind, 'json');
     x.assert(
         p.elems[0].error,
-        'only strings can be used as keys in JSON dict, found a number (`-1.2`)',
+        'only strings and object paths can be used as keys in JSON dict, found a number (`-1.2`)',
     );
     x.assert(p.elems[0].getErrorText(), '{-1.2: 2}');
     x.assert(p.elems[0].getRaw().length, 1);
@@ -1218,12 +1222,13 @@ assert-css: (".item-left sup", {"color": |color|})`);
     p.parse();
     x.assert(
         p.errors[0].message,
-        'only strings can be used as keys in JSON dict, found a boolean (`true`)');
+        'only strings and object paths can be used as keys in JSON dict, found a boolean (`true`)',
+    );
     x.assert(p.elems.length, 1);
     x.assert(p.elems[0].kind, 'json');
     x.assert(
         p.elems[0].error,
-        'only strings can be used as keys in JSON dict, found a boolean (`true`)',
+        'only strings and object paths can be used as keys in JSON dict, found a boolean (`true`)',
     );
     x.assert(p.elems[0].getErrorText(), '{true: 1}');
 
@@ -1232,12 +1237,13 @@ assert-css: (".item-left sup", {"color": |color|})`);
     p.parse();
     x.assert(
         p.errors[0].message,
-        'only strings can be used as keys in JSON dict, found an ident (`hello`)');
+        'only strings and object paths can be used as keys in JSON dict, found an ident (`hello`)',
+    );
     x.assert(p.elems.length, 1);
     x.assert(p.elems[0].kind, 'json');
     x.assert(
         p.elems[0].error,
-        'only strings can be used as keys in JSON dict, found an ident (`hello`)',
+        'only strings and object paths can be used as keys in JSON dict, found an ident (`hello`)',
     );
     x.assert(p.elems[0].getErrorText(), '{hello: 1}');
 
@@ -1246,12 +1252,15 @@ assert-css: (".item-left sup", {"color": |color|})`);
     p.parse();
     x.assert(
         p.errors[0].message,
-        'only strings can be used as keys in JSON dict, found a JSON dict (`{"a": 2}`)');
+        'only strings and object paths can be used as keys in JSON dict, found a JSON dict \
+(`{"a": 2}`)',
+    );
     x.assert(p.elems.length, 1);
     x.assert(p.elems[0].kind, 'json');
     x.assert(
         p.elems[0].error,
-        'only strings can be used as keys in JSON dict, found a JSON dict (`{"a": 2}`)',
+        'only strings and object paths can be used as keys in JSON dict, found a JSON dict \
+(`{"a": 2}`)',
     );
     x.assert(p.elems[0].getErrorText(), '{{"a": 2}: 1}');
     x.assert(p.elems[0].getRaw().length, 1);
@@ -1310,12 +1319,13 @@ assert-css: (".item-left sup", {"color": |color|})`);
     p.parse();
     x.assert(
         p.errors[0].message,
-        'only strings can be used as keys in JSON dict, found an array (`[1, 2]`)');
+        'only strings and object paths can be used as keys in JSON dict, found an array (`[1, 2]`)',
+    );
     x.assert(p.elems.length, 1);
     x.assert(p.elems[0].kind, 'json');
     x.assert(
         p.elems[0].error,
-        'only strings can be used as keys in JSON dict, found an array (`[1, 2]`)',
+        'only strings and object paths can be used as keys in JSON dict, found an array (`[1, 2]`)',
     );
     x.assert(p.elems[0].getErrorText(), '{[1, 2]: 1}');
     x.assert(p.elems[0].getRaw().length, 1);


### PR DESCRIPTION
Part of https://github.com/GuillaumeGomez/browser-UI-test/issues/559.