### PR TITLE
Add support for object-path types in `compare-elements-property` command

### DIFF
--- a/src/commands/assert.js
+++ b/src/commands/assert.js
@@ -11,29 +11,13 @@ const {
     validatePositionDictV2,
     commonPositionCheckCode,
     commonSizeCheckCode,
+    generateCheckObjectPaths,
 } = require('./utils.js');
 const { COLOR_CHECK_ERROR } = require('../consts.js');
 const { cleanString } = require('../parser.js');
 const { validator } = require('../validator.js');
 // Not the same `utils.js`!
 const { hasError } = require('../utils.js');
-
-function generateCheckObjectPaths() {
-    return `\
-function checkObjectPaths(object, path, callback, notFoundCallback) {
-    const found = [];
-
-    for (const subPath of path) {
-        found.push(subPath);
-        if (object === undefined || object === null) {
-            notFoundCallback(found);
-            return;
-        }
-        object = object[subPath];
-    }
-    callback(object);
-}`;
-}
 
 function parseAssertCssInner(parser, assertFalse) {
     const jsonValidator = {

--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -385,6 +385,23 @@ const ${errorsVarName} = [];
 ${checker}`;
 }
 
+function generateCheckObjectPaths() {
+    return `\
+function checkObjectPaths(object, path, callback, notFoundCallback) {
+    const found = [];
+
+    for (const subPath of path) {
+        found.push(subPath);
+        if (object === undefined || object === null) {
+            notFoundCallback(found);
+            return;
+        }
+        object = object[subPath];
+    }
+    callback(object);
+}`;
+}
+
 module.exports = {
     'getAndSetElements': getAndSetElements,
     'getInsertStrings': getInsertStrings,
@@ -396,4 +413,5 @@ module.exports = {
     'validatePositionDictV2': validatePositionDictV2,
     'commonPositionCheckCode': commonPositionCheckCode,
     'commonSizeCheckCode': commonSizeCheckCode,
+    'generateCheckObjectPaths': generateCheckObjectPaths,
 };

--- a/src/parser.js
+++ b/src/parser.js
@@ -151,6 +151,13 @@ function isExpressionCompatible(elem) {
     return elem.kind === 'tuple' && elem.canBeExpression === true;
 }
 
+function isArrayElementCompatible(expected, elem) {
+    if (['string', 'object-path'].includes(expected.kind)) {
+        return ['string', 'object-path'].includes(elem.kind);
+    }
+    return expected.kind === elem.kind;
+}
+
 // Used to concatenate all elements into a string, like `1 + "a" + 12` -> "1a12".
 function concatExprAsString(elems) {
     let out = '';
@@ -488,7 +495,7 @@ class ArrayElement extends Element {
             ) {
                 this.needCheck = true;
                 return null;
-            } else if (values[i].kind !== values[0].kind) {
+            } else if (!isArrayElementCompatible(values[0], values[i])) {
                 this.error = 'all array\'s elements must be of the same kind: expected ' +
                     `array of \`${values[0].kind}\` (because the first element is of this ` +
                     `kind), found \`${values[i].kind}\` at position ${i}`;
@@ -1005,7 +1012,10 @@ found \`${showEnd(prevElem)}\``;
                 endChar = c;
                 break;
             } else if (isStringChar(c)) {
-                checker(c, arg => this.parseString(endChars, arg));
+                checker(c, arg => this.parseString(
+                    separator !== null ? [...endChars, separator] : endChars,
+                    arg,
+                ));
             } else if (c === '{') {
                 checker(c, this.parseJson);
             } else if (isWhiteSpace(c)) {

--- a/src/validator.js
+++ b/src/validator.js
@@ -352,24 +352,25 @@ function validateArray(parser, allowedSyntax, validator) {
         return parser;
     }
     // Allowed by default and optional to specify.
-    const allowEmpty = allowedSyntax.allowEmpty !== false;
+    const allowEmptyValues = allowedSyntax.allowEmptyValues !== false;
 
-    const allowedForType = getObjectValue(allowedSyntax.valueTypes, arrayElems[0].kind);
-    if (allowedForType === undefined) {
-        const exp = Object.keys(allowedSyntax.valueTypes).join(' or ');
-        return validator.makeError(
-            `expected an array of ${exp} elements, found an array of \
-${arrayElems[0].kind} (${arrayElems[0].getErrorText()})`);
-    } else if (!isObject(allowedForType)) {
-        throw new Error('"valueTypes" values should be objects (in array validator)');
-    }
-    allowedForType.kind = arrayElems[0].kind;
     for (const value of arrayElems) {
+        const allowedForType = getObjectValue(allowedSyntax.valueTypes, value.kind);
+        if (allowedForType === undefined) {
+            const exp = Object.keys(allowedSyntax.valueTypes).join(' or ');
+            return validator.makeError(
+                `expected an array of ${exp} elements, found an array of \
+${arrayElems[0].kind} (${arrayElems[0].getErrorText()})`);
+        } else if (!isObject(allowedForType)) {
+            throw new Error('"valueTypes" values should be objects (in array validator)');
+        }
+
+        allowedForType.kind = value.kind;
         const ret = validator.validatorInner(value, allowedForType);
         if (hasError(ret)) {
             return ret;
         }
-        if (!allowEmpty && value.getStringValue().length === 0) {
+        if (!allowEmptyValues && value.getStringValue().length === 0) {
             return validator.makeError(
                 `empty values (\`${value.getErrorText()}\`) are not allowed`,
             );
@@ -566,6 +567,8 @@ Format looks like this:
                     allowed: ['null'],
                 },
             },
+            // optional
+            allowEmptyValues: true,
         },
         {
             kind: 'json',

--- a/tests/api-output/parseCompareElementsProperty/basic-1.toml
+++ b/tests/api-output/parseCompareElementsProperty/basic-1.toml
@@ -3,14 +3,44 @@ instructions = [
 if (parseCompareElementsProp1 === null) { throw '\"a\" not found'; }
 let parseCompareElementsProp2 = await page.$(\"b\");
 if (parseCompareElementsProp2 === null) { throw '\"b\" not found'; }
-const parseCompareElementsProps = [\"margin\"];
+const parseCompareElementsProps = [[\"margin\"]];
 for (const property of parseCompareElementsProps) {
     const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
-        return String(e[p]);
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        return ret;
     }, property);
     await parseCompareElementsProp2.evaluate((e, v, p) => {
-        if (v !== String(e[p])) {
-            throw p + \": `\" + v + \"` !== `\" + String(e[p]) + \"`\";
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        if (v !== ret) {
+            throw p + \": `\" + v + \"` !== `\" + ret + \"`\";
         }
     }, value, property);
 }""",

--- a/tests/api-output/parseCompareElementsProperty/multiline-2.toml
+++ b/tests/api-output/parseCompareElementsProperty/multiline-2.toml
@@ -3,14 +3,44 @@ instructions = [
 if (parseCompareElementsProp1 === null) { throw '\"a\" not found'; }
 let parseCompareElementsProp2 = await page.$(\"b\");
 if (parseCompareElementsProp2 === null) { throw '\"b\" not found'; }
-const parseCompareElementsProps = [\"margin\"];
+const parseCompareElementsProps = [[\"margin\"]];
 for (const property of parseCompareElementsProps) {
     const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
-        return String(e[p]);
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        return ret;
     }, property);
     await parseCompareElementsProp2.evaluate((e, v, p) => {
-        if (v !== String(e[p])) {
-            throw p + \": `\" + v + \"` !== `\" + String(e[p]) + \"`\";
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        if (v !== ret) {
+            throw p + \": `\" + v + \"` !== `\" + ret + \"`\";
         }
     }, value, property);
 }""",

--- a/tests/api-output/parseCompareElementsProperty/object-path-1.toml
+++ b/tests/api-output/parseCompareElementsProperty/object-path-1.toml
@@ -1,13 +1,11 @@
 instructions = [
-  """let parseCompareElementsProp1 = await page.$x(\"//a\");
-if (parseCompareElementsProp1.length === 0) { throw 'XPath \"//a\" not found'; }
-parseCompareElementsProp1 = parseCompareElementsProp1[0];
+  """let parseCompareElementsProp1 = await page.$(\"a\");
+if (parseCompareElementsProp1 === null) { throw '\"a\" not found'; }
 let parseCompareElementsProp2 = await page.$(\"b\");
 if (parseCompareElementsProp2 === null) { throw '\"b\" not found'; }
-const parseCompareElementsProps = [[\"margin\"]];
+const parseCompareElementsProps = [[\"a\",\"b\"]];
 for (const property of parseCompareElementsProps) {
-    try {
-const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
+    const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
         function checkObjectPaths(object, path, callback, notFoundCallback) {
             const found = [];
 
@@ -45,7 +43,6 @@ const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
             throw p + \": `\" + v + \"` !== `\" + ret + \"`\";
         }
     }, value, property);
-} catch(e) { continue; } throw \"assert didn't fail\";
 }""",
 ]
 wait = false

--- a/tests/api-output/parseCompareElementsProperty/object-path-2.toml
+++ b/tests/api-output/parseCompareElementsProperty/object-path-2.toml
@@ -1,13 +1,11 @@
 instructions = [
-  """let parseCompareElementsProp1 = await page.$x(\"//a\");
-if (parseCompareElementsProp1.length === 0) { throw 'XPath \"//a\" not found'; }
-parseCompareElementsProp1 = parseCompareElementsProp1[0];
+  """let parseCompareElementsProp1 = await page.$(\"a\");
+if (parseCompareElementsProp1 === null) { throw '\"a\" not found'; }
 let parseCompareElementsProp2 = await page.$(\"b\");
 if (parseCompareElementsProp2 === null) { throw '\"b\" not found'; }
-const parseCompareElementsProps = [[\"margin\"]];
+const parseCompareElementsProps = [[\"margin\"],[\"a\",\"b\"]];
 for (const property of parseCompareElementsProps) {
-    try {
-const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
+    const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
         function checkObjectPaths(object, path, callback, notFoundCallback) {
             const found = [];
 
@@ -45,7 +43,6 @@ const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
             throw p + \": `\" + v + \"` !== `\" + ret + \"`\";
         }
     }, value, property);
-} catch(e) { continue; } throw \"assert didn't fail\";
 }""",
 ]
 wait = false

--- a/tests/api-output/parseCompareElementsProperty/xpath-1.toml
+++ b/tests/api-output/parseCompareElementsProperty/xpath-1.toml
@@ -4,14 +4,44 @@ if (parseCompareElementsProp1.length === 0) { throw 'XPath \"//a\" not found'; }
 parseCompareElementsProp1 = parseCompareElementsProp1[0];
 let parseCompareElementsProp2 = await page.$(\"b\");
 if (parseCompareElementsProp2 === null) { throw '\"b\" not found'; }
-const parseCompareElementsProps = [\"margin\"];
+const parseCompareElementsProps = [[\"margin\"]];
 for (const property of parseCompareElementsProps) {
     const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
-        return String(e[p]);
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        return ret;
     }, property);
     await parseCompareElementsProp2.evaluate((e, v, p) => {
-        if (v !== String(e[p])) {
-            throw p + \": `\" + v + \"` !== `\" + String(e[p]) + \"`\";
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        if (v !== ret) {
+            throw p + \": `\" + v + \"` !== `\" + ret + \"`\";
         }
     }, value, property);
 }""",

--- a/tests/api-output/parseCompareElementsProperty/xpath-2.toml
+++ b/tests/api-output/parseCompareElementsProperty/xpath-2.toml
@@ -4,14 +4,44 @@ if (parseCompareElementsProp1 === null) { throw '\"a\" not found'; }
 let parseCompareElementsProp2 = await page.$x(\"//b\");
 if (parseCompareElementsProp2.length === 0) { throw 'XPath \"//b\" not found'; }
 parseCompareElementsProp2 = parseCompareElementsProp2[0];
-const parseCompareElementsProps = [\"margin\"];
+const parseCompareElementsProps = [[\"margin\"]];
 for (const property of parseCompareElementsProps) {
     const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
-        return String(e[p]);
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        return ret;
     }, property);
     await parseCompareElementsProp2.evaluate((e, v, p) => {
-        if (v !== String(e[p])) {
-            throw p + \": `\" + v + \"` !== `\" + String(e[p]) + \"`\";
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        if (v !== ret) {
+            throw p + \": `\" + v + \"` !== `\" + ret + \"`\";
         }
     }, value, property);
 }""",

--- a/tests/api-output/parseCompareElementsProperty/xpath-3.toml
+++ b/tests/api-output/parseCompareElementsProperty/xpath-3.toml
@@ -5,14 +5,44 @@ parseCompareElementsProp1 = parseCompareElementsProp1[0];
 let parseCompareElementsProp2 = await page.$x(\"//b\");
 if (parseCompareElementsProp2.length === 0) { throw 'XPath \"//b\" not found'; }
 parseCompareElementsProp2 = parseCompareElementsProp2[0];
-const parseCompareElementsProps = [\"margin\"];
+const parseCompareElementsProps = [[\"margin\"]];
 for (const property of parseCompareElementsProps) {
     const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
-        return String(e[p]);
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        return ret;
     }, property);
     await parseCompareElementsProp2.evaluate((e, v, p) => {
-        if (v !== String(e[p])) {
-            throw p + \": `\" + v + \"` !== `\" + String(e[p]) + \"`\";
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        if (v !== ret) {
+            throw p + \": `\" + v + \"` !== `\" + ret + \"`\";
         }
     }, value, property);
 }""",

--- a/tests/api-output/parseCompareElementsPropertyFalse/basic-1.toml
+++ b/tests/api-output/parseCompareElementsPropertyFalse/basic-1.toml
@@ -3,15 +3,45 @@ instructions = [
 if (parseCompareElementsProp1 === null) { throw '\"a\" not found'; }
 let parseCompareElementsProp2 = await page.$(\"b\");
 if (parseCompareElementsProp2 === null) { throw '\"b\" not found'; }
-const parseCompareElementsProps = [\"margin\"];
+const parseCompareElementsProps = [[\"margin\"]];
 for (const property of parseCompareElementsProps) {
     try {
 const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
-        return String(e[p]);
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        return ret;
     }, property);
     await parseCompareElementsProp2.evaluate((e, v, p) => {
-        if (v !== String(e[p])) {
-            throw p + \": `\" + v + \"` !== `\" + String(e[p]) + \"`\";
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        if (v !== ret) {
+            throw p + \": `\" + v + \"` !== `\" + ret + \"`\";
         }
     }, value, property);
 } catch(e) { continue; } throw \"assert didn't fail\";

--- a/tests/api-output/parseCompareElementsPropertyFalse/multiline-2.toml
+++ b/tests/api-output/parseCompareElementsPropertyFalse/multiline-2.toml
@@ -3,15 +3,45 @@ instructions = [
 if (parseCompareElementsProp1 === null) { throw '\"a\" not found'; }
 let parseCompareElementsProp2 = await page.$(\"b\");
 if (parseCompareElementsProp2 === null) { throw '\"b\" not found'; }
-const parseCompareElementsProps = [\"margin\"];
+const parseCompareElementsProps = [[\"margin\"]];
 for (const property of parseCompareElementsProps) {
     try {
 const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
-        return String(e[p]);
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        return ret;
     }, property);
     await parseCompareElementsProp2.evaluate((e, v, p) => {
-        if (v !== String(e[p])) {
-            throw p + \": `\" + v + \"` !== `\" + String(e[p]) + \"`\";
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        if (v !== ret) {
+            throw p + \": `\" + v + \"` !== `\" + ret + \"`\";
         }
     }, value, property);
 } catch(e) { continue; } throw \"assert didn't fail\";

--- a/tests/api-output/parseCompareElementsPropertyFalse/object-path-1.toml
+++ b/tests/api-output/parseCompareElementsPropertyFalse/object-path-1.toml
@@ -1,10 +1,9 @@
 instructions = [
-  """let parseCompareElementsProp1 = await page.$x(\"//a\");
-if (parseCompareElementsProp1.length === 0) { throw 'XPath \"//a\" not found'; }
-parseCompareElementsProp1 = parseCompareElementsProp1[0];
+  """let parseCompareElementsProp1 = await page.$(\"a\");
+if (parseCompareElementsProp1 === null) { throw '\"a\" not found'; }
 let parseCompareElementsProp2 = await page.$(\"b\");
 if (parseCompareElementsProp2 === null) { throw '\"b\" not found'; }
-const parseCompareElementsProps = [[\"margin\"]];
+const parseCompareElementsProps = [[\"a\",\"b\"]];
 for (const property of parseCompareElementsProps) {
     try {
 const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {

--- a/tests/api-output/parseCompareElementsPropertyFalse/object-path-2.toml
+++ b/tests/api-output/parseCompareElementsPropertyFalse/object-path-2.toml
@@ -1,10 +1,9 @@
 instructions = [
-  """let parseCompareElementsProp1 = await page.$x(\"//a\");
-if (parseCompareElementsProp1.length === 0) { throw 'XPath \"//a\" not found'; }
-parseCompareElementsProp1 = parseCompareElementsProp1[0];
+  """let parseCompareElementsProp1 = await page.$(\"a\");
+if (parseCompareElementsProp1 === null) { throw '\"a\" not found'; }
 let parseCompareElementsProp2 = await page.$(\"b\");
 if (parseCompareElementsProp2 === null) { throw '\"b\" not found'; }
-const parseCompareElementsProps = [[\"margin\"]];
+const parseCompareElementsProps = [[\"margin\"],[\"a\",\"b\"]];
 for (const property of parseCompareElementsProps) {
     try {
 const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {

--- a/tests/api-output/parseCompareElementsPropertyFalse/xpath-2.toml
+++ b/tests/api-output/parseCompareElementsPropertyFalse/xpath-2.toml
@@ -4,15 +4,45 @@ if (parseCompareElementsProp1 === null) { throw '\"a\" not found'; }
 let parseCompareElementsProp2 = await page.$x(\"//b\");
 if (parseCompareElementsProp2.length === 0) { throw 'XPath \"//b\" not found'; }
 parseCompareElementsProp2 = parseCompareElementsProp2[0];
-const parseCompareElementsProps = [\"margin\"];
+const parseCompareElementsProps = [[\"margin\"]];
 for (const property of parseCompareElementsProps) {
     try {
 const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
-        return String(e[p]);
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        return ret;
     }, property);
     await parseCompareElementsProp2.evaluate((e, v, p) => {
-        if (v !== String(e[p])) {
-            throw p + \": `\" + v + \"` !== `\" + String(e[p]) + \"`\";
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        if (v !== ret) {
+            throw p + \": `\" + v + \"` !== `\" + ret + \"`\";
         }
     }, value, property);
 } catch(e) { continue; } throw \"assert didn't fail\";

--- a/tests/api-output/parseCompareElementsPropertyFalse/xpath-3.toml
+++ b/tests/api-output/parseCompareElementsPropertyFalse/xpath-3.toml
@@ -5,15 +5,45 @@ parseCompareElementsProp1 = parseCompareElementsProp1[0];
 let parseCompareElementsProp2 = await page.$x(\"//b\");
 if (parseCompareElementsProp2.length === 0) { throw 'XPath \"//b\" not found'; }
 parseCompareElementsProp2 = parseCompareElementsProp2[0];
-const parseCompareElementsProps = [\"margin\"];
+const parseCompareElementsProps = [[\"margin\"]];
 for (const property of parseCompareElementsProps) {
     try {
 const value = await parseCompareElementsProp1.evaluateHandle((e, p) => {
-        return String(e[p]);
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        return ret;
     }, property);
     await parseCompareElementsProp2.evaluate((e, v, p) => {
-        if (v !== String(e[p])) {
-            throw p + \": `\" + v + \"` !== `\" + String(e[p]) + \"`\";
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
+        let ret = 'undefined';
+        checkObjectPaths(e, p, found => ret = String(found), notFound => {});
+        if (v !== ret) {
+            throw p + \": `\" + v + \"` !== `\" + ret + \"`\";
         }
     }, value, property);
 } catch(e) { continue; } throw \"assert didn't fail\";

--- a/tests/api-output/parseCompareElementsSizeNear/basic-10.toml
+++ b/tests/api-output/parseCompareElementsSizeNear/basic-10.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(width1, width2, \"width\", 1);
 browserCompareValuesNear(height1, height2, \"height\", 2);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",

--- a/tests/api-output/parseCompareElementsSizeNear/basic-11.toml
+++ b/tests/api-output/parseCompareElementsSizeNear/basic-11.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 2);
 browserCompareValuesNear(width1, width2, \"width\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",

--- a/tests/api-output/parseCompareElementsSizeNear/basic-8.toml
+++ b/tests/api-output/parseCompareElementsSizeNear/basic-8.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(width1, width2, \"width\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",
 ]

--- a/tests/api-output/parseCompareElementsSizeNear/basic-9.toml
+++ b/tests/api-output/parseCompareElementsSizeNear/basic-9.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",
 ]

--- a/tests/api-output/parseCompareElementsSizeNear/multiline-3.toml
+++ b/tests/api-output/parseCompareElementsSizeNear/multiline-3.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",
 ]

--- a/tests/api-output/parseCompareElementsSizeNear/warn-1.toml
+++ b/tests/api-output/parseCompareElementsSizeNear/warn-1.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(width1, width2, \"width\", 0);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",
 ]

--- a/tests/api-output/parseCompareElementsSizeNear/warn-2.toml
+++ b/tests/api-output/parseCompareElementsSizeNear/warn-2.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 0);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",
 ]

--- a/tests/api-output/parseCompareElementsSizeNear/xpath-1.toml
+++ b/tests/api-output/parseCompareElementsSizeNear/xpath-1.toml
@@ -16,7 +16,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -25,7 +25,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 2);
 browserCompareValuesNear(width1, width2, \"width\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",

--- a/tests/api-output/parseCompareElementsSizeNear/xpath-2.toml
+++ b/tests/api-output/parseCompareElementsSizeNear/xpath-2.toml
@@ -16,7 +16,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -25,7 +25,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 2);
 browserCompareValuesNear(width1, width2, \"width\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",

--- a/tests/api-output/parseCompareElementsSizeNear/xpath-3.toml
+++ b/tests/api-output/parseCompareElementsSizeNear/xpath-3.toml
@@ -17,7 +17,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -26,7 +26,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 2);
 browserCompareValuesNear(width1, width2, \"width\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",

--- a/tests/api-output/parseCompareElementsSizeNearFalse/basic-10.toml
+++ b/tests/api-output/parseCompareElementsSizeNearFalse/basic-10.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(width1, width2, \"width\", 1);
 browserCompareValuesNear(height1, height2, \"height\", 2);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",

--- a/tests/api-output/parseCompareElementsSizeNearFalse/basic-11.toml
+++ b/tests/api-output/parseCompareElementsSizeNearFalse/basic-11.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 2);
 browserCompareValuesNear(width1, width2, \"width\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",

--- a/tests/api-output/parseCompareElementsSizeNearFalse/basic-8.toml
+++ b/tests/api-output/parseCompareElementsSizeNearFalse/basic-8.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(width1, width2, \"width\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",
 ]

--- a/tests/api-output/parseCompareElementsSizeNearFalse/basic-9.toml
+++ b/tests/api-output/parseCompareElementsSizeNearFalse/basic-9.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",
 ]

--- a/tests/api-output/parseCompareElementsSizeNearFalse/multiline-3.toml
+++ b/tests/api-output/parseCompareElementsSizeNearFalse/multiline-3.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",
 ]

--- a/tests/api-output/parseCompareElementsSizeNearFalse/warn-1.toml
+++ b/tests/api-output/parseCompareElementsSizeNearFalse/warn-1.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(width1, width2, \"width\", 0);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",
 ]

--- a/tests/api-output/parseCompareElementsSizeNearFalse/warn-2.toml
+++ b/tests/api-output/parseCompareElementsSizeNearFalse/warn-2.toml
@@ -15,7 +15,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -24,7 +24,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 0);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",
 ]

--- a/tests/api-output/parseCompareElementsSizeNearFalse/xpath-1.toml
+++ b/tests/api-output/parseCompareElementsSizeNearFalse/xpath-1.toml
@@ -16,7 +16,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -25,7 +25,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 2);
 browserCompareValuesNear(width1, width2, \"width\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",

--- a/tests/api-output/parseCompareElementsSizeNearFalse/xpath-2.toml
+++ b/tests/api-output/parseCompareElementsSizeNearFalse/xpath-2.toml
@@ -16,7 +16,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -25,7 +25,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 2);
 browserCompareValuesNear(width1, width2, \"width\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",

--- a/tests/api-output/parseCompareElementsSizeNearFalse/xpath-3.toml
+++ b/tests/api-output/parseCompareElementsSizeNearFalse/xpath-3.toml
@@ -17,7 +17,7 @@ function browserGetElementSizes2(e) {
     return [Math.round(width), Math.round(height)];
 }
 function browserCompareValuesNear(v1, v2, kind, maxDelta) {
-    delta = Math.abs(v1 - v2);
+    const delta = Math.abs(v1 - v2);
     if (delta > maxDelta) {
         err = \"delta for \" + kind + \" values too large: \" + delta + \" > \" + maxDelta;
     }
@@ -26,7 +26,6 @@ function browserCompareValuesNear(v1, v2, kind, maxDelta) {
 const [width1, height1] = browserGetElementSizes1(elem1);
 const [width2, height2] = browserGetElementSizes2(elem2);
 let err = null;
-let delta;
 browserCompareValuesNear(height1, height2, \"height\", 2);
 browserCompareValuesNear(width1, width2, \"width\", 1);
 }, parseCompareElementsSizeNear1, parseCompareElementsSizeNear2);""",

--- a/tools/api.js
+++ b/tools/api.js
@@ -799,6 +799,10 @@ function checkCompareElementsProperty(x, func) {
     // Multiline
     func('("a"\n, "b", \n1)', 'multiline-1');
     func('("a",\n "b",\n [\n"margin"])', 'multiline-2');
+
+    // Multiline
+    func('("a", "b", ["a"."b"])', 'object-path-1');
+    func('("a", "b", ["margin", "a"."b"])', 'object-path-2');
 }
 
 function checkCompareElementsSize(x, func) {

--- a/tools/parser.js
+++ b/tools/parser.js
@@ -768,6 +768,37 @@ function checkArray(x) {
 first element is of this kind), found `string` at position 1',
     );
     x.assert(p.elems.length, 1);
+
+    // Checks that array of strings and of object-path is ok.
+    p = new Parser('["a", "a"."b"]');
+    p.parse();
+    x.assert(p.errors, []);
+    x.assert(p.elems.length, 1);
+    x.assert(p.elems[0].kind, 'array');
+    x.assert(p.elems[0].getErrorText(), '["a", "a"."b"]');
+    x.assert(p.elems[0].error, null);
+    x.assert(p.elems[0].getRaw().length, 2);
+    x.assert(p.elems[0].getRaw()[0].error, null);
+    x.assert(p.elems[0].getRaw()[0].kind, 'string');
+    x.assert(p.elems[0].getRaw()[0].getRaw(), 'a');
+    x.assert(p.elems[0].getRaw()[1].error, null);
+    x.assert(p.elems[0].getRaw()[1].kind, 'object-path');
+    x.assert(p.elems[0].getRaw()[1].getRaw().length, 2);
+
+    p = new Parser('["a"."b", "a"]');
+    p.parse();
+    x.assert(p.errors, []);
+    x.assert(p.elems.length, 1);
+    x.assert(p.elems[0].kind, 'array');
+    x.assert(p.elems[0].getErrorText(), '["a"."b", "a"]');
+    x.assert(p.elems[0].error, null);
+    x.assert(p.elems[0].getRaw().length, 2);
+    x.assert(p.elems[0].getRaw()[0].error, null);
+    x.assert(p.elems[0].getRaw()[0].kind, 'object-path');
+    x.assert(p.elems[0].getRaw()[0].getRaw().length, 2);
+    x.assert(p.elems[0].getRaw()[1].error, null);
+    x.assert(p.elems[0].getRaw()[1].kind, 'string');
+    x.assert(p.elems[0].getRaw()[1].getRaw(), 'a');
 }
 
 function checkIdent(x) {


### PR DESCRIPTION
Part of https://github.com/GuillaumeGomez/browser-UI-test/issues/559.