### PR TITLE
Add object-path support for set-document-property and `set-window-property` commands

### DIFF
--- a/goml-script.md
+++ b/goml-script.md
@@ -1049,20 +1049,26 @@ Another thing to be noted: if you don't care whether the selector exists or not 
 
 #### compare-elements-property
 
-**compare-elements-property** command allows you to check that two DOM elements' CSS properties are equal. Examples:
+**compare-elements-property** command allows you to check that two DOM elements' properties are equal. Examples:
 
 ```
-compare-elements-property: ("element1", "//element2", ["CSS property1", "CSS property2", ...])
-compare-elements-property: ("//element1", "element2", ["CSS property1", "CSS property2", ...])
+compare-elements-property: ("element1", "//element2", ["property1", "property2", ...])
+compare-elements-property: ("//element1", "element2", ["property1", "property2", ...])
+
+// Object-paths are also supported:
+compare-elements-property: ("//element1", "element2", ["property1"."sub", ...])
 ```
 
 #### compare-elements-property-false
 
-**compare-elements-property-false** command allows you to check that two DOM elements' CSS properties are different. If one of the elements doesn't exist, the command will fail. Examples:
+**compare-elements-property-false** command allows you to check that two DOM elements' properties are different. If one of the elements doesn't exist, the command will fail. Examples:
 
 ```
-compare-elements-property-false: ("element1", "//element2", ["CSS property1", "CSS property2", ...])
-compare-elements-property-false: ("//element1", "element2", ["CSS property1", "CSS property2", ...])
+compare-elements-property-false: ("element1", "//element2", ["property1", "property2", ...])
+compare-elements-property-false: ("//element1", "element2", ["property1", "property2", ...])
+
+// Object-paths are also supported:
+compare-elements-property-false: ("//element1", "element2", ["property1"."sub", ...])
 ```
 
 Another thing to be noted: if you don't care whether the selector exists or not either, take a look at the [`expect-failure`](#expect-failure) command too.

--- a/goml-script.md
+++ b/goml-script.md
@@ -1560,6 +1560,9 @@ assert-window-property: ({"devicePixelRatio": "0.5"}, [STARTS_WITH])
 
 ```
 set-document-property: {"title": "a", "linkColor": "blue"}
+
+// It works with object paths as well:
+set-document-property: {"activeElement"."innerText": "new text"}
 ```
 
 #### set-font-size
@@ -1627,6 +1630,9 @@ set-timeout: 0 // no more timeout, to be used cautiously!
 
 ```
 set-window-property: {"scrollX": 12, "screenLeft": "a"}
+
+// It works with object paths as well:
+set-window-property: {"document"."activeElement"."innerText": "new text"}
 ```
 
 #### set-window-size

--- a/src/commands/assert.js
+++ b/src/commands/assert.js
@@ -380,16 +380,16 @@ function parseAssertPropertyInner(parser, assertFalse) {
     const jsonValidator = {
         kind: 'json',
         keyTypes: {
-            'string': [],
+            string: [],
             'object-path': [],
         },
         valueTypes: {
-            'string': {},
-            'number': {
+            string: {},
+            number: {
                 allowNegative: true,
                 allowFloat: true,
             },
-            'ident': {
+            ident: {
                 allowed: ['null'],
             },
         },

--- a/src/commands/compare.js
+++ b/src/commands/compare.js
@@ -274,7 +274,7 @@ function parseCompareElementsPropertyInner(parser, assertFalse) {
                     kind: 'array',
                     allowEmptyValues: false,
                     valueTypes: {
-                        'string': {},
+                        string: {},
                         'object-path': {},
                     },
                 },
@@ -359,7 +359,7 @@ function parseCompareElementsPositionInner(parser, assertFalse) {
                 {
                     kind: 'array',
                     valueTypes: {
-                        'string': {
+                        string: {
                             allowed: ['x', 'y'],
                         },
                     },

--- a/src/commands/dom_modifiers.js
+++ b/src/commands/dom_modifiers.js
@@ -9,11 +9,11 @@ function innerParseCssAttribute(parser, argName, varName, allowNullIdent, callba
     const jsonValidator = {
         kind: 'json',
         keyTypes: {
-            'string': [],
+            string: [],
         },
         valueTypes: {
-            'string': {},
-            'number': {
+            string: {},
+            number: {
                 allowNegative: true,
                 allowFloat: true,
             },

--- a/tests/api-output/parseSetDocumentProperty/basic-1.toml
+++ b/tests/api-output/parseSetDocumentProperty/basic-1.toml
@@ -1,10 +1,20 @@
 instructions = [
   """await page.evaluate(() => {
-    const parsePropDict = new Map([
-        [\"a\", \"2\"]
-    ]);
+    function setObjValue(object, path, value) {
+        for (let i = 0; i < path.length - 1; ++i) {
+            const subPath = path[i];
+            if (object[subPath] === undefined || object[subPath] === null) {
+                object[subPath] = {};
+            }
+            object = object[subPath];
+        }
+        object[path[path.length - 1]] = value;
+    }
+    const parsePropDict = [
+        [[\"a\"], \"2\"]
+    ];
     for (const [parsePropKey, parsePropValue] of parsePropDict) {
-        document[parsePropKey] = parsePropValue;
+        setObjValue(document, parsePropKey, parsePropValue);
     }
 });""",
 ]

--- a/tests/api-output/parseSetDocumentProperty/escape-1.toml
+++ b/tests/api-output/parseSetDocumentProperty/escape-1.toml
@@ -1,11 +1,21 @@
 instructions = [
   """await page.evaluate(() => {
-    const parsePropDict = new Map([
-        [\"a\", \"2\"],
-        [\"\\\"b\", \"\\'b\"]
-    ]);
+    function setObjValue(object, path, value) {
+        for (let i = 0; i < path.length - 1; ++i) {
+            const subPath = path[i];
+            if (object[subPath] === undefined || object[subPath] === null) {
+                object[subPath] = {};
+            }
+            object = object[subPath];
+        }
+        object[path[path.length - 1]] = value;
+    }
+    const parsePropDict = [
+        [[\"a\"], \"2\"],
+        [[\"\\\"b\"], \"\\'b\"]
+    ];
     for (const [parsePropKey, parsePropValue] of parsePropDict) {
-        document[parsePropKey] = parsePropValue;
+        setObjValue(document, parsePropKey, parsePropValue);
     }
 });""",
 ]

--- a/tests/api-output/parseSetDocumentProperty/object-path-1.toml
+++ b/tests/api-output/parseSetDocumentProperty/object-path-1.toml
@@ -11,10 +11,10 @@ instructions = [
         object[path[path.length - 1]] = value;
     }
     const parsePropDict = [
-        [[\"a\"], \"2\"]
+        [[\"a\",\"b\"], \"2\"]
     ];
     for (const [parsePropKey, parsePropValue] of parsePropDict) {
-        setObjValue(window, parsePropKey, parsePropValue);
+        setObjValue(document, parsePropKey, parsePropValue);
     }
 });""",
 ]

--- a/tests/api-output/parseSetDocumentProperty/object-path-2.toml
+++ b/tests/api-output/parseSetDocumentProperty/object-path-2.toml
@@ -11,10 +11,11 @@ instructions = [
         object[path[path.length - 1]] = value;
     }
     const parsePropDict = [
-        [[\"a\"], \"2\"]
+        [[\"a\"], \"2\"],
+        [[\"b\",\"c\"], \"b\"]
     ];
     for (const [parsePropKey, parsePropValue] of parsePropDict) {
-        setObjValue(window, parsePropKey, parsePropValue);
+        setObjValue(document, parsePropKey, parsePropValue);
     }
 });""",
 ]

--- a/tests/api-output/parseSetWindowProperty/escape-1.toml
+++ b/tests/api-output/parseSetWindowProperty/escape-1.toml
@@ -1,11 +1,21 @@
 instructions = [
   """await page.evaluate(() => {
-    const parsePropDict = new Map([
-        [\"a\", \"2\"],
-        [\"\\\"b\", \"\\'b\"]
-    ]);
+    function setObjValue(object, path, value) {
+        for (let i = 0; i < path.length - 1; ++i) {
+            const subPath = path[i];
+            if (object[subPath] === undefined || object[subPath] === null) {
+                object[subPath] = {};
+            }
+            object = object[subPath];
+        }
+        object[path[path.length - 1]] = value;
+    }
+    const parsePropDict = [
+        [[\"a\"], \"2\"],
+        [[\"\\\"b\"], \"\\'b\"]
+    ];
     for (const [parsePropKey, parsePropValue] of parsePropDict) {
-        window[parsePropKey] = parsePropValue;
+        setObjValue(window, parsePropKey, parsePropValue);
     }
 });""",
 ]

--- a/tests/api-output/parseSetWindowProperty/object-path-1.toml
+++ b/tests/api-output/parseSetWindowProperty/object-path-1.toml
@@ -11,7 +11,7 @@ instructions = [
         object[path[path.length - 1]] = value;
     }
     const parsePropDict = [
-        [[\"a\"], \"2\"]
+        [[\"a\",\"b\"], \"2\"]
     ];
     for (const [parsePropKey, parsePropValue] of parsePropDict) {
         setObjValue(window, parsePropKey, parsePropValue);

--- a/tests/api-output/parseSetWindowProperty/object-path-2.toml
+++ b/tests/api-output/parseSetWindowProperty/object-path-2.toml
@@ -11,7 +11,8 @@ instructions = [
         object[path[path.length - 1]] = value;
     }
     const parsePropDict = [
-        [[\"a\"], \"2\"]
+        [[\"a\"], \"2\"],
+        [[\"b\",\"c\"], \"b\"]
     ];
     for (const [parsePropKey, parsePropValue] of parsePropDict) {
         setObjValue(window, parsePropKey, parsePropValue);

--- a/tests/ui/property.goml
+++ b/tests/ui/property.goml
@@ -6,9 +6,17 @@ assert-window-property-false: {"size": "a"}
 set-window-property: {"size": "a"}
 assert-window-property: {"size": "a"}
 
+assert-window-property-false: {"wa"."wo": "a"}
+set-window-property: {"wa"."wo": "a"}
+assert-window-property: {"wa"."wo": "a"}
+
 assert-document-property-false: {"size": "a"}
 set-document-property: {"size": "a"}
 assert-document-property: {"size": "a"}
+
+assert-document-property-false: {"wa"."wo": "a"}
+set-document-property: {"wa"."wo": "a"}
+assert-document-property: {"wa"."wo": "a"}
 
 assert-property-false: ("header", {"yolo": "a"})
 set-property: ("header", {"yolo": "a"})

--- a/tools/api.js
+++ b/tools/api.js
@@ -2267,6 +2267,10 @@ function checkObjProperty(x, func) {
 
     func('{"a": 2}', 'basic-1');
     func('{"a": "2", "\\"b": "\'b"}', 'escape-1');
+
+    // object-path
+    func('{"a"."b": 2}', 'object-path-1');
+    func('{"a": "2", "b"."c": "b"}', 'object-path-2');
 }
 
 function checkWrite(x, func) {


### PR DESCRIPTION
Part of https://github.com/GuillaumeGomez/browser-UI-test/issues/559.