### PR TITLE
Add support for object-path in `wait-for-document-property`, `wait-for-window-property` and `wait-for-property` commands

### DIFF
--- a/goml-script.md
+++ b/goml-script.md
@@ -1914,6 +1914,9 @@ Examples:
 ```
 wait-for-document-property: {"key": "value"}
 wait-for-document-property: {"key": "value", "key2": "value2"}
+
+// You can also use object-paths:
+wait-for-document-property: {"key"."sub-key": "value"}
 ```
 
 You can use more specific checks as well by using one of the following identifiers: CONTAINS", "ENDS_WITH", "STARTS_WITH", or "NEAR".
@@ -1962,6 +1965,9 @@ wait-for-property: ("#element", {"scrollTop": 10, "name": "hello"})
 // Same with an XPath:
 wait-for-property: ("//*[@id='element']", {"scrollTop": 10})
 wait-for-property: ("//*[@id='element']", {"scrollTop": 10, "name": "hello"})
+
+// You can also use object-paths:
+wait-for-property: ("#element", {"key"."sub-key": "value"})
 ```
 
 If you want to check that a property doesn't exist, you can use `null`:
@@ -2047,6 +2053,9 @@ Examples:
 ```
 wait-for-window-property: {"key": "value"}
 wait-for-window-property: {"key": "value", "key2": "value2"}
+
+// You can also use object-paths:
+wait-for-window-property: {"key"."sub-key": "value"}
 ```
 
 You can use more specific checks as well by using one of the following identifiers: CONTAINS", "ENDS_WITH", "STARTS_WITH", or "NEAR".

--- a/tests/api-output/parseWaitForDocumentProperty/basic-3.toml
+++ b/tests/api-output/parseWaitForDocumentProperty/basic-3.toml
@@ -5,23 +5,46 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
         const errors = [];
-        const propertyDict = {\"a\":\"b\"};
+        const propertyDict = [[[\"a\"],\"b\"]];
         const undefProps = [];
         for (const prop of undefProps) {
-            if (document[prop] !== undefined && document[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-                continue;
-            }
+            checkObjectPaths(document, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (document[propertyKey] === undefined) {
-                errors.push(\"document doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(document[propertyKey]);
-            if (property !== propertyValue) {
-                errors.push(\"expected `\" + propertyValue + \"` for document property `\" + propertyKey + \"`, found `\" + property + \"`\");
-            }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(document, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"document doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (property !== propertyValue) {
+                    errors.push(\"expected `\" + propertyValue + \"` for document property `\" + propertyKey + \"`, found `\" + property + \"`\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"document doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForDocumentProperty/basic-4.toml
+++ b/tests/api-output/parseWaitForDocumentProperty/basic-4.toml
@@ -5,23 +5,46 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
         const errors = [];
-        const propertyDict = {\"a\":\"b\"};
+        const propertyDict = [[[\"a\"],\"b\"]];
         const undefProps = [];
         for (const prop of undefProps) {
-            if (document[prop] !== undefined && document[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-                continue;
-            }
+            checkObjectPaths(document, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (document[propertyKey] === undefined) {
-                errors.push(\"document doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(document[propertyKey]);
-            if (property !== propertyValue) {
-                errors.push(\"expected `\" + propertyValue + \"` for document property `\" + propertyKey + \"`, found `\" + property + \"`\");
-            }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(document, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"document doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (property !== propertyValue) {
+                    errors.push(\"expected `\" + propertyValue + \"` for document property `\" + propertyKey + \"`, found `\" + property + \"`\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"document doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForDocumentProperty/basic-6.toml
+++ b/tests/api-output/parseWaitForDocumentProperty/basic-6.toml
@@ -5,23 +5,46 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
         const errors = [];
-        const propertyDict = {\"\\\"a\":\"\\'b\"};
+        const propertyDict = [[[\"\\\"a\"],\"\\'b\"]];
         const undefProps = [];
         for (const prop of undefProps) {
-            if (document[prop] !== undefined && document[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-                continue;
-            }
+            checkObjectPaths(document, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (document[propertyKey] === undefined) {
-                errors.push(\"document doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(document[propertyKey]);
-            if (property !== propertyValue) {
-                errors.push(\"expected `\" + propertyValue + \"` for document property `\" + propertyKey + \"`, found `\" + property + \"`\");
-            }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(document, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"document doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (property !== propertyValue) {
+                    errors.push(\"expected `\" + propertyValue + \"` for document property `\" + propertyKey + \"`, found `\" + property + \"`\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"document doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForDocumentProperty/extra-1.toml
+++ b/tests/api-output/parseWaitForDocumentProperty/extra-1.toml
@@ -5,23 +5,46 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
         const errors = [];
-        const propertyDict = {\"a\":\"b\"};
+        const propertyDict = [[[\"a\"],\"b\"]];
         const undefProps = [];
         for (const prop of undefProps) {
-            if (document[prop] !== undefined && document[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-                continue;
-            }
+            checkObjectPaths(document, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (document[propertyKey] === undefined) {
-                errors.push(\"document doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(document[propertyKey]);
-            if (!property.startsWith(propertyValue)) {
-                errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
-            }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(document, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"document doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (!property.startsWith(propertyValue)) {
+                    errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"document doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForDocumentProperty/extra-2.toml
+++ b/tests/api-output/parseWaitForDocumentProperty/extra-2.toml
@@ -5,23 +5,46 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
         const errors = [];
-        const propertyDict = {\"a\":\"b\"};
+        const propertyDict = [[[\"a\"],\"b\"]];
         const undefProps = [];
         for (const prop of undefProps) {
-            if (document[prop] !== undefined && document[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-                continue;
-            }
+            checkObjectPaths(document, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (document[propertyKey] === undefined) {
-                errors.push(\"document doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(document[propertyKey]);
-            if (!property.startsWith(propertyValue)) {
-                errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
-            }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(document, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"document doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (!property.startsWith(propertyValue)) {
+                    errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"document doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForDocumentProperty/extra-3.toml
+++ b/tests/api-output/parseWaitForDocumentProperty/extra-3.toml
@@ -5,23 +5,46 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
-        const errors = [];
-        const propertyDict = {};
-        const undefProps = [\"a\"];
-        for (const prop of undefProps) {
-            if (document[prop] !== undefined && document[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (document[propertyKey] === undefined) {
-                errors.push(\"document doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(document[propertyKey]);
-            if (!property.startsWith(propertyValue)) {
-                errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
-            }
+        const errors = [];
+        const propertyDict = [];
+        const undefProps = [[\"a\"]];
+        for (const prop of undefProps) {
+            checkObjectPaths(document, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
+        }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(document, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"document doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (!property.startsWith(propertyValue)) {
+                    errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"document doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForDocumentProperty/extra-4.toml
+++ b/tests/api-output/parseWaitForDocumentProperty/extra-4.toml
@@ -5,26 +5,49 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
         const errors = [];
-        const propertyDict = {\"a\":\"b\"};
+        const propertyDict = [[[\"a\"],\"b\"]];
         const undefProps = [];
         for (const prop of undefProps) {
-            if (document[prop] !== undefined && document[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-                continue;
-            }
+            checkObjectPaths(document, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (document[propertyKey] === undefined) {
-                errors.push(\"document doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(document[propertyKey]);
-            if (!property.startsWith(propertyValue)) {
-                errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
-            }
-            if (!property.endsWith(propertyValue)) {
-                errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't end with `\" + propertyValue + \"`\");
-            }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(document, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"document doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (!property.startsWith(propertyValue)) {
+                    errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
+                }
+                if (!property.endsWith(propertyValue)) {
+                    errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't end with `\" + propertyValue + \"`\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"document doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForDocumentProperty/extra-5.toml
+++ b/tests/api-output/parseWaitForDocumentProperty/extra-5.toml
@@ -5,26 +5,49 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
-        const errors = [];
-        const propertyDict = {\"a\":\"b\"};
-        const undefProps = [\"c\"];
-        for (const prop of undefProps) {
-            if (document[prop] !== undefined && document[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + document[prop] + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (document[propertyKey] === undefined) {
-                errors.push(\"document doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(document[propertyKey]);
-            if (!property.startsWith(propertyValue)) {
-                errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
-            }
-            if (!property.endsWith(propertyValue)) {
-                errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't end with `\" + propertyValue + \"`\");
-            }
+        const errors = [];
+        const propertyDict = [[[\"a\"],\"b\"]];
+        const undefProps = [[\"c\"]];
+        for (const prop of undefProps) {
+            checkObjectPaths(document, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
+        }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(document, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"document doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (!property.startsWith(propertyValue)) {
+                    errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
+                }
+                if (!property.endsWith(propertyValue)) {
+                    errors.push(\"document property `\" + propertyKey + \"` (`\" + property + \"`) doesn't end with `\" + propertyValue + \"`\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"document doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForDocumentProperty/object-path-1.toml
+++ b/tests/api-output/parseWaitForDocumentProperty/object-path-1.toml
@@ -19,8 +19,8 @@ while (true) {
             callback(object);
         }
         const errors = [];
-        const propertyDict = [];
-        const undefProps = [[\"a\"]];
+        const propertyDict = [[[\"x\",\"y\"],\"1\"]];
+        const undefProps = [];
         for (const prop of undefProps) {
             checkObjectPaths(document, prop, val => {
                 if (val !== undefined && val !== null) {

--- a/tests/api-output/parseWaitForDocumentProperty/object-path-2.toml
+++ b/tests/api-output/parseWaitForDocumentProperty/object-path-2.toml
@@ -19,8 +19,8 @@ while (true) {
             callback(object);
         }
         const errors = [];
-        const propertyDict = [];
-        const undefProps = [[\"a\"]];
+        const propertyDict = [[[\"x\",\"y\"],\"1\"],[[\"z\"],\"3\"]];
+        const undefProps = [];
         for (const prop of undefProps) {
             checkObjectPaths(document, prop, val => {
                 if (val !== undefined && val !== null) {

--- a/tests/api-output/parseWaitForProperty/basic-1.toml
+++ b/tests/api-output/parseWaitForProperty/basic-1.toml
@@ -1,25 +1,47 @@
 instructions = [
   """async function checkPropForElem(elem) {
     return await elem.evaluate(e => {
-        const nonMatchingProps = [];
-        const parseWaitForPropDict = {};
-        const nullProps = [];
-        for (const parseWaitForPropKey of nullProps) {
-            if (e[parseWaitForPropKey] !== undefined && e[parseWaitForPropKey] !== null) {
-                const prop = e[parseWaitForPropKey];
-                nonMatchingProps.push(\"Expected property `\" + parseWaitForPropKey + \"` to not exist, found: `\" + prop + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [parseWaitForPropKey, parseWaitForPropValue] of Object.entries(parseWaitForPropDict)) {
-            if (e[parseWaitForPropKey] === undefined || e[parseWaitForPropKey] === null) {
-                nonMatchingProps.push(\"Property named `\" + parseWaitForPropKey + \"` doesn't exist\");
-                continue;
-            }
-            const prop = e[parseWaitForPropKey];
-            if (prop !== parseWaitForPropValue) {
-                nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + prop + \"`\");
-            }
+
+        const nonMatchingProps = [];
+        const parseWaitForPropDict = [];
+        const nullProps = [];
+        for (const prop of nullProps) {
+            checkObjectPaths(e, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                    return;
+                }
+            }, _notFound => {
+            });
+        }
+        for (const [parseWaitForPropKey, parseWaitForPropValue] of parseWaitForPropDict) {
+            checkObjectPaths(e, parseWaitForPropKey, val => {
+                if (val === undefined) {
+                    const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+                    return;
+                }
+                if (val !== parseWaitForPropValue) {
+                    nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + val + \"`\");
+                }
+            }, _notFound => {
+                const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+            });
         }
         return nonMatchingProps;
     });

--- a/tests/api-output/parseWaitForProperty/basic-2.toml
+++ b/tests/api-output/parseWaitForProperty/basic-2.toml
@@ -1,25 +1,47 @@
 instructions = [
   """async function checkPropForElem(elem) {
     return await elem.evaluate(e => {
-        const nonMatchingProps = [];
-        const parseWaitForPropDict = {\"x\":\"1\"};
-        const nullProps = [];
-        for (const parseWaitForPropKey of nullProps) {
-            if (e[parseWaitForPropKey] !== undefined && e[parseWaitForPropKey] !== null) {
-                const prop = e[parseWaitForPropKey];
-                nonMatchingProps.push(\"Expected property `\" + parseWaitForPropKey + \"` to not exist, found: `\" + prop + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [parseWaitForPropKey, parseWaitForPropValue] of Object.entries(parseWaitForPropDict)) {
-            if (e[parseWaitForPropKey] === undefined || e[parseWaitForPropKey] === null) {
-                nonMatchingProps.push(\"Property named `\" + parseWaitForPropKey + \"` doesn't exist\");
-                continue;
-            }
-            const prop = e[parseWaitForPropKey];
-            if (prop !== parseWaitForPropValue) {
-                nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + prop + \"`\");
-            }
+
+        const nonMatchingProps = [];
+        const parseWaitForPropDict = [[[\"x\"],\"1\"]];
+        const nullProps = [];
+        for (const prop of nullProps) {
+            checkObjectPaths(e, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                    return;
+                }
+            }, _notFound => {
+            });
+        }
+        for (const [parseWaitForPropKey, parseWaitForPropValue] of parseWaitForPropDict) {
+            checkObjectPaths(e, parseWaitForPropKey, val => {
+                if (val === undefined) {
+                    const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+                    return;
+                }
+                if (val !== parseWaitForPropValue) {
+                    nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + val + \"`\");
+                }
+            }, _notFound => {
+                const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+            });
         }
         return nonMatchingProps;
     });

--- a/tests/api-output/parseWaitForProperty/color-1.toml
+++ b/tests/api-output/parseWaitForProperty/color-1.toml
@@ -1,25 +1,47 @@
 instructions = [
   """async function checkPropForElem(elem) {
     return await elem.evaluate(e => {
-        const nonMatchingProps = [];
-        const parseWaitForPropDict = {\"color\":\"blue\"};
-        const nullProps = [];
-        for (const parseWaitForPropKey of nullProps) {
-            if (e[parseWaitForPropKey] !== undefined && e[parseWaitForPropKey] !== null) {
-                const prop = e[parseWaitForPropKey];
-                nonMatchingProps.push(\"Expected property `\" + parseWaitForPropKey + \"` to not exist, found: `\" + prop + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [parseWaitForPropKey, parseWaitForPropValue] of Object.entries(parseWaitForPropDict)) {
-            if (e[parseWaitForPropKey] === undefined || e[parseWaitForPropKey] === null) {
-                nonMatchingProps.push(\"Property named `\" + parseWaitForPropKey + \"` doesn't exist\");
-                continue;
-            }
-            const prop = e[parseWaitForPropKey];
-            if (prop !== parseWaitForPropValue) {
-                nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + prop + \"`\");
-            }
+
+        const nonMatchingProps = [];
+        const parseWaitForPropDict = [[[\"color\"],\"blue\"]];
+        const nullProps = [];
+        for (const prop of nullProps) {
+            checkObjectPaths(e, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                    return;
+                }
+            }, _notFound => {
+            });
+        }
+        for (const [parseWaitForPropKey, parseWaitForPropValue] of parseWaitForPropDict) {
+            checkObjectPaths(e, parseWaitForPropKey, val => {
+                if (val === undefined) {
+                    const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+                    return;
+                }
+                if (val !== parseWaitForPropValue) {
+                    nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + val + \"`\");
+                }
+            }, _notFound => {
+                const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+            });
         }
         return nonMatchingProps;
     });

--- a/tests/api-output/parseWaitForProperty/extra-1.toml
+++ b/tests/api-output/parseWaitForProperty/extra-1.toml
@@ -1,25 +1,47 @@
 instructions = [
   """async function checkPropForElem(elem) {
     return await elem.evaluate(e => {
-        const nonMatchingProps = [];
-        const parseWaitForPropDict = {\"x\":\"1\"};
-        const nullProps = [];
-        for (const parseWaitForPropKey of nullProps) {
-            if (e[parseWaitForPropKey] !== undefined && e[parseWaitForPropKey] !== null) {
-                const prop = e[parseWaitForPropKey];
-                nonMatchingProps.push(\"Expected property `\" + parseWaitForPropKey + \"` to not exist, found: `\" + prop + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [parseWaitForPropKey, parseWaitForPropValue] of Object.entries(parseWaitForPropDict)) {
-            if (e[parseWaitForPropKey] === undefined || e[parseWaitForPropKey] === null) {
-                nonMatchingProps.push(\"Property named `\" + parseWaitForPropKey + \"` doesn't exist\");
-                continue;
-            }
-            const prop = e[parseWaitForPropKey];
-            if (prop !== parseWaitForPropValue) {
-                nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + prop + \"`\");
-            }
+
+        const nonMatchingProps = [];
+        const parseWaitForPropDict = [[[\"x\"],\"1\"]];
+        const nullProps = [];
+        for (const prop of nullProps) {
+            checkObjectPaths(e, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                    return;
+                }
+            }, _notFound => {
+            });
+        }
+        for (const [parseWaitForPropKey, parseWaitForPropValue] of parseWaitForPropDict) {
+            checkObjectPaths(e, parseWaitForPropKey, val => {
+                if (val === undefined) {
+                    const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+                    return;
+                }
+                if (val !== parseWaitForPropValue) {
+                    nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + val + \"`\");
+                }
+            }, _notFound => {
+                const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+            });
         }
         return nonMatchingProps;
     });

--- a/tests/api-output/parseWaitForProperty/extra-2.toml
+++ b/tests/api-output/parseWaitForProperty/extra-2.toml
@@ -1,25 +1,47 @@
 instructions = [
   """async function checkPropForElem(elem) {
     return await elem.evaluate(e => {
-        const nonMatchingProps = [];
-        const parseWaitForPropDict = {\"x\":\"1\"};
-        const nullProps = [];
-        for (const parseWaitForPropKey of nullProps) {
-            if (e[parseWaitForPropKey] !== undefined && e[parseWaitForPropKey] !== null) {
-                const prop = e[parseWaitForPropKey];
-                nonMatchingProps.push(\"Expected property `\" + parseWaitForPropKey + \"` to not exist, found: `\" + prop + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [parseWaitForPropKey, parseWaitForPropValue] of Object.entries(parseWaitForPropDict)) {
-            if (e[parseWaitForPropKey] === undefined || e[parseWaitForPropKey] === null) {
-                nonMatchingProps.push(\"Property named `\" + parseWaitForPropKey + \"` doesn't exist\");
-                continue;
-            }
-            const prop = e[parseWaitForPropKey];
-            if (!prop.includes(parseWaitForPropValue)) {
-                nonMatchingProps.push(\"property `\" + parseWaitForPropKey + \"` (`\" + prop + \"`) doesn't contain `\" + parseWaitForPropValue + \"` (for CONTAINS check)\");
-            }
+
+        const nonMatchingProps = [];
+        const parseWaitForPropDict = [[[\"x\"],\"1\"]];
+        const nullProps = [];
+        for (const prop of nullProps) {
+            checkObjectPaths(e, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                    return;
+                }
+            }, _notFound => {
+            });
+        }
+        for (const [parseWaitForPropKey, parseWaitForPropValue] of parseWaitForPropDict) {
+            checkObjectPaths(e, parseWaitForPropKey, val => {
+                if (val === undefined) {
+                    const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+                    return;
+                }
+                if (!val.includes(parseWaitForPropValue)) {
+                    nonMatchingProps.push(\"property `\" + parseWaitForPropKey + \"` (`\" + val + \"`) doesn't contain `\" + parseWaitForPropValue + \"` (for CONTAINS check)\");
+                }
+            }, _notFound => {
+                const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+            });
         }
         return nonMatchingProps;
     });

--- a/tests/api-output/parseWaitForProperty/extra-3.toml
+++ b/tests/api-output/parseWaitForProperty/extra-3.toml
@@ -1,25 +1,47 @@
 instructions = [
   """async function checkPropForElem(elem) {
     return await elem.evaluate(e => {
-        const nonMatchingProps = [];
-        const parseWaitForPropDict = {\"x\":\"1\"};
-        const nullProps = [];
-        for (const parseWaitForPropKey of nullProps) {
-            if (e[parseWaitForPropKey] !== undefined && e[parseWaitForPropKey] !== null) {
-                const prop = e[parseWaitForPropKey];
-                nonMatchingProps.push(\"Expected property `\" + parseWaitForPropKey + \"` to not exist, found: `\" + prop + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [parseWaitForPropKey, parseWaitForPropValue] of Object.entries(parseWaitForPropDict)) {
-            if (e[parseWaitForPropKey] === undefined || e[parseWaitForPropKey] === null) {
-                nonMatchingProps.push(\"Property named `\" + parseWaitForPropKey + \"` doesn't exist\");
-                continue;
-            }
-            const prop = e[parseWaitForPropKey];
-            if (!prop.includes(parseWaitForPropValue)) {
-                nonMatchingProps.push(\"property `\" + parseWaitForPropKey + \"` (`\" + prop + \"`) doesn't contain `\" + parseWaitForPropValue + \"` (for CONTAINS check)\");
-            }
+
+        const nonMatchingProps = [];
+        const parseWaitForPropDict = [[[\"x\"],\"1\"]];
+        const nullProps = [];
+        for (const prop of nullProps) {
+            checkObjectPaths(e, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                    return;
+                }
+            }, _notFound => {
+            });
+        }
+        for (const [parseWaitForPropKey, parseWaitForPropValue] of parseWaitForPropDict) {
+            checkObjectPaths(e, parseWaitForPropKey, val => {
+                if (val === undefined) {
+                    const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+                    return;
+                }
+                if (!val.includes(parseWaitForPropValue)) {
+                    nonMatchingProps.push(\"property `\" + parseWaitForPropKey + \"` (`\" + val + \"`) doesn't contain `\" + parseWaitForPropValue + \"` (for CONTAINS check)\");
+                }
+            }, _notFound => {
+                const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+            });
         }
         return nonMatchingProps;
     });

--- a/tests/api-output/parseWaitForProperty/object-path-1.toml
+++ b/tests/api-output/parseWaitForProperty/object-path-1.toml
@@ -16,7 +16,7 @@ instructions = [
         }
 
         const nonMatchingProps = [];
-        const parseWaitForPropDict = [[[\"x\"],\"1\"],[[\"y\"],\"2\"]];
+        const parseWaitForPropDict = [[[\"x\",\"y\"],\"1\"]];
         const nullProps = [];
         for (const prop of nullProps) {
             checkObjectPaths(e, prop, val => {

--- a/tests/api-output/parseWaitForProperty/object-path-2.toml
+++ b/tests/api-output/parseWaitForProperty/object-path-2.toml
@@ -16,7 +16,7 @@ instructions = [
         }
 
         const nonMatchingProps = [];
-        const parseWaitForPropDict = [[[\"x\"],\"1\"],[[\"y\"],\"2\"]];
+        const parseWaitForPropDict = [[[\"x\",\"y\"],\"1\"],[[\"z\"],\"3\"]];
         const nullProps = [];
         for (const prop of nullProps) {
             checkObjectPaths(e, prop, val => {

--- a/tests/api-output/parseWaitForProperty/pseudo-1.toml
+++ b/tests/api-output/parseWaitForProperty/pseudo-1.toml
@@ -1,25 +1,47 @@
 instructions = [
   """async function checkPropForElem(elem) {
     return await elem.evaluate(e => {
-        const nonMatchingProps = [];
-        const parseWaitForPropDict = {\"x\":\"1\",\"y\":\"2\"};
-        const nullProps = [];
-        for (const parseWaitForPropKey of nullProps) {
-            if (e[parseWaitForPropKey] !== undefined && e[parseWaitForPropKey] !== null) {
-                const prop = e[parseWaitForPropKey];
-                nonMatchingProps.push(\"Expected property `\" + parseWaitForPropKey + \"` to not exist, found: `\" + prop + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [parseWaitForPropKey, parseWaitForPropValue] of Object.entries(parseWaitForPropDict)) {
-            if (e[parseWaitForPropKey] === undefined || e[parseWaitForPropKey] === null) {
-                nonMatchingProps.push(\"Property named `\" + parseWaitForPropKey + \"` doesn't exist\");
-                continue;
-            }
-            const prop = e[parseWaitForPropKey];
-            if (prop !== parseWaitForPropValue) {
-                nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + prop + \"`\");
-            }
+
+        const nonMatchingProps = [];
+        const parseWaitForPropDict = [[[\"x\"],\"1\"],[[\"y\"],\"2\"]];
+        const nullProps = [];
+        for (const prop of nullProps) {
+            checkObjectPaths(e, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                    return;
+                }
+            }, _notFound => {
+            });
+        }
+        for (const [parseWaitForPropKey, parseWaitForPropValue] of parseWaitForPropDict) {
+            checkObjectPaths(e, parseWaitForPropKey, val => {
+                if (val === undefined) {
+                    const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+                    return;
+                }
+                if (val !== parseWaitForPropValue) {
+                    nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + val + \"`\");
+                }
+            }, _notFound => {
+                const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+            });
         }
         return nonMatchingProps;
     });

--- a/tests/api-output/parseWaitForProperty/xpath-2.toml
+++ b/tests/api-output/parseWaitForProperty/xpath-2.toml
@@ -1,25 +1,47 @@
 instructions = [
   """async function checkPropForElem(elem) {
     return await elem.evaluate(e => {
-        const nonMatchingProps = [];
-        const parseWaitForPropDict = {};
-        const nullProps = [];
-        for (const parseWaitForPropKey of nullProps) {
-            if (e[parseWaitForPropKey] !== undefined && e[parseWaitForPropKey] !== null) {
-                const prop = e[parseWaitForPropKey];
-                nonMatchingProps.push(\"Expected property `\" + parseWaitForPropKey + \"` to not exist, found: `\" + prop + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [parseWaitForPropKey, parseWaitForPropValue] of Object.entries(parseWaitForPropDict)) {
-            if (e[parseWaitForPropKey] === undefined || e[parseWaitForPropKey] === null) {
-                nonMatchingProps.push(\"Property named `\" + parseWaitForPropKey + \"` doesn't exist\");
-                continue;
-            }
-            const prop = e[parseWaitForPropKey];
-            if (prop !== parseWaitForPropValue) {
-                nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + prop + \"`\");
-            }
+
+        const nonMatchingProps = [];
+        const parseWaitForPropDict = [];
+        const nullProps = [];
+        for (const prop of nullProps) {
+            checkObjectPaths(e, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                    return;
+                }
+            }, _notFound => {
+            });
+        }
+        for (const [parseWaitForPropKey, parseWaitForPropValue] of parseWaitForPropDict) {
+            checkObjectPaths(e, parseWaitForPropKey, val => {
+                if (val === undefined) {
+                    const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+                    return;
+                }
+                if (val !== parseWaitForPropValue) {
+                    nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + val + \"`\");
+                }
+            }, _notFound => {
+                const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+            });
         }
         return nonMatchingProps;
     });

--- a/tests/api-output/parseWaitForProperty/xpath-3.toml
+++ b/tests/api-output/parseWaitForProperty/xpath-3.toml
@@ -1,25 +1,47 @@
 instructions = [
   """async function checkPropForElem(elem) {
     return await elem.evaluate(e => {
-        const nonMatchingProps = [];
-        const parseWaitForPropDict = {\"x\":\"1\"};
-        const nullProps = [];
-        for (const parseWaitForPropKey of nullProps) {
-            if (e[parseWaitForPropKey] !== undefined && e[parseWaitForPropKey] !== null) {
-                const prop = e[parseWaitForPropKey];
-                nonMatchingProps.push(\"Expected property `\" + parseWaitForPropKey + \"` to not exist, found: `\" + prop + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [parseWaitForPropKey, parseWaitForPropValue] of Object.entries(parseWaitForPropDict)) {
-            if (e[parseWaitForPropKey] === undefined || e[parseWaitForPropKey] === null) {
-                nonMatchingProps.push(\"Property named `\" + parseWaitForPropKey + \"` doesn't exist\");
-                continue;
-            }
-            const prop = e[parseWaitForPropKey];
-            if (prop !== parseWaitForPropValue) {
-                nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + prop + \"`\");
-            }
+
+        const nonMatchingProps = [];
+        const parseWaitForPropDict = [[[\"x\"],\"1\"]];
+        const nullProps = [];
+        for (const prop of nullProps) {
+            checkObjectPaths(e, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                    return;
+                }
+            }, _notFound => {
+            });
+        }
+        for (const [parseWaitForPropKey, parseWaitForPropValue] of parseWaitForPropDict) {
+            checkObjectPaths(e, parseWaitForPropKey, val => {
+                if (val === undefined) {
+                    const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                    nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+                    return;
+                }
+                if (val !== parseWaitForPropValue) {
+                    nonMatchingProps.push(\"expected `\" + parseWaitForPropValue + \"` for property `\" + parseWaitForPropKey + \"`, found `\" + val + \"`\");
+                }
+            }, _notFound => {
+                const p = parseWaitForPropKey.map(p => `\"${p}\"`).join('.');
+                nonMatchingProps.push(\"Property `\" + p + \"` doesn't exist\");
+            });
         }
         return nonMatchingProps;
     });

--- a/tests/api-output/parseWaitForWindowProperty/basic-3.toml
+++ b/tests/api-output/parseWaitForWindowProperty/basic-3.toml
@@ -5,23 +5,46 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
         const errors = [];
-        const propertyDict = {\"a\":\"b\"};
+        const propertyDict = [[[\"a\"],\"b\"]];
         const undefProps = [];
         for (const prop of undefProps) {
-            if (window[prop] !== undefined && window[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-                continue;
-            }
+            checkObjectPaths(window, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (window[propertyKey] === undefined) {
-                errors.push(\"window doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(window[propertyKey]);
-            if (property !== propertyValue) {
-                errors.push(\"expected `\" + propertyValue + \"` for window property `\" + propertyKey + \"`, found `\" + property + \"`\");
-            }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(window, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"window doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (property !== propertyValue) {
+                    errors.push(\"expected `\" + propertyValue + \"` for window property `\" + propertyKey + \"`, found `\" + property + \"`\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"window doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForWindowProperty/basic-4.toml
+++ b/tests/api-output/parseWaitForWindowProperty/basic-4.toml
@@ -5,23 +5,46 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
         const errors = [];
-        const propertyDict = {\"a\":\"b\"};
+        const propertyDict = [[[\"a\"],\"b\"]];
         const undefProps = [];
         for (const prop of undefProps) {
-            if (window[prop] !== undefined && window[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-                continue;
-            }
+            checkObjectPaths(window, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (window[propertyKey] === undefined) {
-                errors.push(\"window doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(window[propertyKey]);
-            if (property !== propertyValue) {
-                errors.push(\"expected `\" + propertyValue + \"` for window property `\" + propertyKey + \"`, found `\" + property + \"`\");
-            }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(window, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"window doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (property !== propertyValue) {
+                    errors.push(\"expected `\" + propertyValue + \"` for window property `\" + propertyKey + \"`, found `\" + property + \"`\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"window doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForWindowProperty/basic-6.toml
+++ b/tests/api-output/parseWaitForWindowProperty/basic-6.toml
@@ -5,23 +5,46 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
         const errors = [];
-        const propertyDict = {\"\\\"a\":\"\\'b\"};
+        const propertyDict = [[[\"\\\"a\"],\"\\'b\"]];
         const undefProps = [];
         for (const prop of undefProps) {
-            if (window[prop] !== undefined && window[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-                continue;
-            }
+            checkObjectPaths(window, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (window[propertyKey] === undefined) {
-                errors.push(\"window doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(window[propertyKey]);
-            if (property !== propertyValue) {
-                errors.push(\"expected `\" + propertyValue + \"` for window property `\" + propertyKey + \"`, found `\" + property + \"`\");
-            }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(window, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"window doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (property !== propertyValue) {
+                    errors.push(\"expected `\" + propertyValue + \"` for window property `\" + propertyKey + \"`, found `\" + property + \"`\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"window doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForWindowProperty/basic-7.toml
+++ b/tests/api-output/parseWaitForWindowProperty/basic-7.toml
@@ -5,23 +5,46 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
-        const errors = [];
-        const propertyDict = {};
-        const undefProps = [\"a\"];
-        for (const prop of undefProps) {
-            if (window[prop] !== undefined && window[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (window[propertyKey] === undefined) {
-                errors.push(\"window doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(window[propertyKey]);
-            if (property !== propertyValue) {
-                errors.push(\"expected `\" + propertyValue + \"` for window property `\" + propertyKey + \"`, found `\" + property + \"`\");
-            }
+        const errors = [];
+        const propertyDict = [];
+        const undefProps = [[\"a\"]];
+        for (const prop of undefProps) {
+            checkObjectPaths(window, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
+        }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(window, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"window doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (property !== propertyValue) {
+                    errors.push(\"expected `\" + propertyValue + \"` for window property `\" + propertyKey + \"`, found `\" + property + \"`\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"window doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForWindowProperty/extra-1.toml
+++ b/tests/api-output/parseWaitForWindowProperty/extra-1.toml
@@ -5,23 +5,46 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
         const errors = [];
-        const propertyDict = {\"a\":\"b\"};
+        const propertyDict = [[[\"a\"],\"b\"]];
         const undefProps = [];
         for (const prop of undefProps) {
-            if (window[prop] !== undefined && window[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-                continue;
-            }
+            checkObjectPaths(window, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (window[propertyKey] === undefined) {
-                errors.push(\"window doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(window[propertyKey]);
-            if (!property.startsWith(propertyValue)) {
-                errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
-            }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(window, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"window doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (!property.startsWith(propertyValue)) {
+                    errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"window doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForWindowProperty/extra-2.toml
+++ b/tests/api-output/parseWaitForWindowProperty/extra-2.toml
@@ -5,23 +5,46 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
         const errors = [];
-        const propertyDict = {\"a\":\"b\"};
+        const propertyDict = [[[\"a\"],\"b\"]];
         const undefProps = [];
         for (const prop of undefProps) {
-            if (window[prop] !== undefined && window[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-                continue;
-            }
+            checkObjectPaths(window, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (window[propertyKey] === undefined) {
-                errors.push(\"window doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(window[propertyKey]);
-            if (!property.startsWith(propertyValue)) {
-                errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
-            }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(window, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"window doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (!property.startsWith(propertyValue)) {
+                    errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"window doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForWindowProperty/extra-3.toml
+++ b/tests/api-output/parseWaitForWindowProperty/extra-3.toml
@@ -5,23 +5,46 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
-        const errors = [];
-        const propertyDict = {};
-        const undefProps = [\"a\"];
-        for (const prop of undefProps) {
-            if (window[prop] !== undefined && window[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (window[propertyKey] === undefined) {
-                errors.push(\"window doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(window[propertyKey]);
-            if (!property.startsWith(propertyValue)) {
-                errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
-            }
+        const errors = [];
+        const propertyDict = [];
+        const undefProps = [[\"a\"]];
+        for (const prop of undefProps) {
+            checkObjectPaths(window, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
+        }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(window, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"window doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (!property.startsWith(propertyValue)) {
+                    errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"window doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForWindowProperty/extra-4.toml
+++ b/tests/api-output/parseWaitForWindowProperty/extra-4.toml
@@ -5,26 +5,49 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
+            }
+            callback(object);
+        }
         const errors = [];
-        const propertyDict = {\"a\":\"b\"};
+        const propertyDict = [[[\"a\"],\"b\"]];
         const undefProps = [];
         for (const prop of undefProps) {
-            if (window[prop] !== undefined && window[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-                continue;
-            }
+            checkObjectPaths(window, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (window[propertyKey] === undefined) {
-                errors.push(\"window doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(window[propertyKey]);
-            if (!property.startsWith(propertyValue)) {
-                errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
-            }
-            if (!property.endsWith(propertyValue)) {
-                errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't end with `\" + propertyValue + \"`\");
-            }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(window, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"window doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (!property.startsWith(propertyValue)) {
+                    errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
+                }
+                if (!property.endsWith(propertyValue)) {
+                    errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't end with `\" + propertyValue + \"`\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"window doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForWindowProperty/extra-5.toml
+++ b/tests/api-output/parseWaitForWindowProperty/extra-5.toml
@@ -5,26 +5,49 @@ let allTime = 0;
 let property = null;
 while (true) {
     property = await page.evaluate(() => {
-        const errors = [];
-        const propertyDict = {\"a\":\"b\"};
-        const undefProps = [\"c\"];
-        for (const prop of undefProps) {
-            if (window[prop] !== undefined && window[prop] !== null) {
-                errors.push(\"Expected property `\" + prop + \"` to not exist, found: `\" + window[prop] + \"`\");
-                continue;
+        function checkObjectPaths(object, path, callback, notFoundCallback) {
+            const found = [];
+
+            for (const subPath of path) {
+                found.push(subPath);
+                if (object === undefined || object === null) {
+                    notFoundCallback(found);
+                    return;
+                }
+                object = object[subPath];
             }
+            callback(object);
         }
-        for (const [propertyKey, propertyValue] of Object.entries(propertyDict)) {
-            if (window[propertyKey] === undefined) {
-                errors.push(\"window doesn't have a property named `\" + propertyKey + \"`\");
-            }
-            const property = String(window[propertyKey]);
-            if (!property.startsWith(propertyValue)) {
-                errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
-            }
-            if (!property.endsWith(propertyValue)) {
-                errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't end with `\" + propertyValue + \"`\");
-            }
+        const errors = [];
+        const propertyDict = [[[\"a\"],\"b\"]];
+        const undefProps = [[\"c\"]];
+        for (const prop of undefProps) {
+            checkObjectPaths(window, prop, val => {
+                if (val !== undefined && val !== null) {
+                    const p = prop.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
+                }
+            }, _notFound => {},
+            );
+        }
+        for (const [propertyKey, propertyValue] of propertyDict) {
+            checkObjectPaths(window, propertyKey, val => {
+                if (val === undefined) {
+                    const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                    errors.push(\"window doesn't have a property `\" + p + \"`\");
+                    return;
+                }
+                const property = String(val);
+                if (!property.startsWith(propertyValue)) {
+                    errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't start with `\" + propertyValue + \"` (for STARTS_WITH check)\");
+                }
+                if (!property.endsWith(propertyValue)) {
+                    errors.push(\"window property `\" + propertyKey + \"` (`\" + property + \"`) doesn't end with `\" + propertyValue + \"`\");
+                }
+            }, _notFound => {
+                const p = propertyKey.map(p => `\"${p}\"`).join('.');
+                errors.push(\"window doesn't have a property `\" + p + \"`\");
+            });
         }
         return errors;
     });

--- a/tests/api-output/parseWaitForWindowProperty/object-path-1.toml
+++ b/tests/api-output/parseWaitForWindowProperty/object-path-1.toml
@@ -19,10 +19,10 @@ while (true) {
             callback(object);
         }
         const errors = [];
-        const propertyDict = [];
-        const undefProps = [[\"a\"]];
+        const propertyDict = [[[\"x\",\"y\"],\"1\"]];
+        const undefProps = [];
         for (const prop of undefProps) {
-            checkObjectPaths(document, prop, val => {
+            checkObjectPaths(window, prop, val => {
                 if (val !== undefined && val !== null) {
                     const p = prop.map(p => `\"${p}\"`).join('.');
                     errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
@@ -31,19 +31,19 @@ while (true) {
             );
         }
         for (const [propertyKey, propertyValue] of propertyDict) {
-            checkObjectPaths(document, propertyKey, val => {
+            checkObjectPaths(window, propertyKey, val => {
                 if (val === undefined) {
                     const p = propertyKey.map(p => `\"${p}\"`).join('.');
-                    errors.push(\"document doesn't have a property `\" + p + \"`\");
+                    errors.push(\"window doesn't have a property `\" + p + \"`\");
                     return;
                 }
                 const property = String(val);
                 if (property !== propertyValue) {
-                    errors.push(\"expected `\" + propertyValue + \"` for document property `\" + propertyKey + \"`, found `\" + property + \"`\");
+                    errors.push(\"expected `\" + propertyValue + \"` for window property `\" + propertyKey + \"`, found `\" + property + \"`\");
                 }
             }, _notFound => {
                 const p = propertyKey.map(p => `\"${p}\"`).join('.');
-                errors.push(\"document doesn't have a property `\" + p + \"`\");
+                errors.push(\"window doesn't have a property `\" + p + \"`\");
             });
         }
         return errors;
@@ -58,7 +58,7 @@ while (true) {
     allTime += timeAdd;
     if (allTime >= timeLimit) {
         const errs = property.join(\", \");
-        throw new Error(\"The following document properties still don't match: [\" + errs + \"]\");
+        throw new Error(\"The following window properties still don't match: [\" + errs + \"]\");
     }
 }""",
 ]

--- a/tests/api-output/parseWaitForWindowProperty/object-path-2.toml
+++ b/tests/api-output/parseWaitForWindowProperty/object-path-2.toml
@@ -19,10 +19,10 @@ while (true) {
             callback(object);
         }
         const errors = [];
-        const propertyDict = [];
-        const undefProps = [[\"a\"]];
+        const propertyDict = [[[\"x\",\"y\"],\"1\"],[[\"z\"],\"3\"]];
+        const undefProps = [];
         for (const prop of undefProps) {
-            checkObjectPaths(document, prop, val => {
+            checkObjectPaths(window, prop, val => {
                 if (val !== undefined && val !== null) {
                     const p = prop.map(p => `\"${p}\"`).join('.');
                     errors.push(\"Expected property `\" + p + \"` to not exist, found: `\" + val + \"`\");
@@ -31,19 +31,19 @@ while (true) {
             );
         }
         for (const [propertyKey, propertyValue] of propertyDict) {
-            checkObjectPaths(document, propertyKey, val => {
+            checkObjectPaths(window, propertyKey, val => {
                 if (val === undefined) {
                     const p = propertyKey.map(p => `\"${p}\"`).join('.');
-                    errors.push(\"document doesn't have a property `\" + p + \"`\");
+                    errors.push(\"window doesn't have a property `\" + p + \"`\");
                     return;
                 }
                 const property = String(val);
                 if (property !== propertyValue) {
-                    errors.push(\"expected `\" + propertyValue + \"` for document property `\" + propertyKey + \"`, found `\" + property + \"`\");
+                    errors.push(\"expected `\" + propertyValue + \"` for window property `\" + propertyKey + \"`, found `\" + property + \"`\");
                 }
             }, _notFound => {
                 const p = propertyKey.map(p => `\"${p}\"`).join('.');
-                errors.push(\"document doesn't have a property `\" + p + \"`\");
+                errors.push(\"window doesn't have a property `\" + p + \"`\");
             });
         }
         return errors;
@@ -58,7 +58,7 @@ while (true) {
     allTime += timeAdd;
     if (allTime >= timeLimit) {
         const errs = property.join(\", \");
-        throw new Error(\"The following document properties still don't match: [\" + errs + \"]\");
+        throw new Error(\"The following window properties still don't match: [\" + errs + \"]\");
     }
 }""",
 ]

--- a/tests/html_files/elements.html
+++ b/tests/html_files/elements.html
@@ -71,8 +71,11 @@ header {
 		<button id="js-local-storage" onclick="updateLocalStorage()">hey</button>
 		<button id="js-wait-local-storage" onclick="updateWaitLocalStorage()">hey</button>
 		<button id="js-wait-window-prop" onclick="updateWaitWindowProp()">hey</button>
+		<button id="js-wait-window-prop2" onclick="updateWaitWindowProp2()">hey</button>
 		<button id="js-wait-document-prop" onclick="updateWaitDocumentProp()">hey</button>
+		<button id="js-wait-document-prop2" onclick="updateWaitDocumentProp2()">hey</button>
 		<button id="js-wait-prop" onclick="updateWaitElementProp()">hey</button>
+		<button id="js-wait-prop2" onclick="updateWaitElementProp2()">hey</button>
 		<button id="js-change-colors" onclick="updateButtonsColor()">hey</button>
 		<button id="js-change-pos" onclick="updateWaitElementPosition()">hey</button>
 		<button id="js-change-size" onclick="updateWaitElementSize()" style="width:30px;height:20px;">hey</button>
@@ -118,14 +121,29 @@ setTimeout(() => {
   if (!window["windowProp"]) { window["windowProp"] = "hello"; } else { window["windowProp"] += "1"; }
 }, 100);
 }
+function updateWaitWindowProp2() {
+setTimeout(() => {
+  window["ba"] = {"x": 12};
+}, 100);
+}
 function updateWaitDocumentProp() {
 setTimeout(() => {
   if (!document["windowProp"]) { document["windowProp"] = "hello"; } else { document["windowProp"] += "1"; }
 }, 100);
 }
+function updateWaitDocumentProp2() {
+setTimeout(() => {
+  document["bob"] = {"y": 15 };
+}, 100);
+}
 function updateWaitElementProp() {
 setTimeout(() => {
   document.getElementById("js-wait-prop")["someProp"] = "hello";
+}, 250);
+}
+function updateWaitElementProp2() {
+setTimeout(() => {
+  document.getElementById("js-wait-prop2")["toto"] = {"z": 78};
 }, 250);
 }
 function updateWaitElementPosition() {

--- a/tests/ui/fail-on-js-error.output
+++ b/tests/ui/fail-on-js-error.output
@@ -2,7 +2,7 @@
 
 fail-on-js-error... FAILED
 [ERROR] `tests/ui/fail-on-js-error.goml` around line 4: JS errors occurred: Error: TypeError: Cannot read properties of null (reading 'hello')
-    at invalid_js (file://$CURRENT_DIR/tests/html_files/elements.html:106:6)
+    at invalid_js (file://$CURRENT_DIR/tests/html_files/elements.html:109:6)
     at HTMLButtonElement.onclick (file://$CURRENT_DIR/tests/html_files/elements.html:69:55)
 
 <= doc-ui tests done: 0 succeeded, 1 failed

--- a/tests/ui/wait-for-document-property.goml
+++ b/tests/ui/wait-for-document-property.goml
@@ -14,3 +14,9 @@ wait-for-document-property: ({"windowProp": "1", "non-existent": null}, ENDS_WIT
 wait-for-document-property: {"windowProp": "tadam"}
 // Check that the script won't stop running anything after the previous command failed.
 assert-document-property: {"windowProp": "tadam"}
+
+// object-path
+assert-document-property: {"bob"."y": null}
+click: "#js-wait-document-prop2"
+// Should wait for 100ms here.
+wait-for-document-property: {"bob"."y": 15}

--- a/tests/ui/wait-for-position.goml
+++ b/tests/ui/wait-for-position.goml
@@ -3,10 +3,10 @@ screenshot-comparison: false
 go-to: "file://" + |CURRENT_DIR| + "/" + |DOC_PATH| + "/elements.html"
 set-timeout: 500
 // Shouldn't wait here since it's already the case.
-wait-for-position: ("#js-change-pos", {"x": 418, "y": 88})
+wait-for-position: ("#js-change-pos", {"x": 543, "y": 88})
 click: "#js-change-pos"
 // Should wait for 250ms here.
-wait-for-position: ("#js-change-pos", {"x": 421})
+wait-for-position: ("#js-change-pos", {"x": 546})
 // We reset the "y" position:
 set-css: ("#js-change-pos", {"margin-top": "0"})
 click: "#js-change-pos"

--- a/tests/ui/wait-for-property.goml
+++ b/tests/ui/wait-for-property.goml
@@ -14,3 +14,9 @@ wait-for-property: ("#created-one", {"hehe": "hoho"})
 wait-for-property: ("#js-wait-prop", {"data-a": "c"})
 // Check that the script won't run anything after the previous command failed.
 assert-property: ("#js-wait-prop", {"data-a": "c"})
+
+// object-path
+assert-property: ("#js-wait-prop2", {"toto"."z": null})
+click: "#js-create-elem2"
+// Should wait for 100ms here.
+wait-for-property: ("#js-wait-prop2", {"toto"."z": 78})

--- a/tests/ui/wait-for-property.output
+++ b/tests/ui/wait-for-property.output
@@ -1,7 +1,7 @@
 => Starting doc-ui tests...
 
 wait-for-property... FAILED
-[ERROR] `tests/ui/wait-for-property.goml` line 14: Error: The following properties still don't match: [Property named `data-a` doesn't exist]: for command `wait-for-property: ("#js-wait-prop", {"data-a": "c"})`
+[ERROR] `tests/ui/wait-for-property.goml` line 14: Error: The following properties still don't match: [Property `"data-a"` doesn't exist]: for command `wait-for-property: ("#js-wait-prop", {"data-a": "c"})`
 
 
 <= doc-ui tests done: 0 succeeded, 1 failed

--- a/tests/ui/wait-for-window-property.goml
+++ b/tests/ui/wait-for-window-property.goml
@@ -14,3 +14,9 @@ wait-for-window-property: ({"windowProp": "1", "non-existent": null}, ENDS_WITH)
 wait-for-window-property: {"windowProp": "tadam"}
 // Check that the script won't stop running anything after the previous command failed.
 assert-window-property: {"windowProp": "tadam"}
+
+// object-path
+assert-window-property: {"ba"."x": null}
+click: "#js-wait-window-prop2"
+// Should wait for 100ms here.
+wait-for-window-property: {"ba"."x": 12}

--- a/tools/api.js
+++ b/tools/api.js
@@ -2161,6 +2161,10 @@ function checkWaitForProperty(x, func) {
     func('("a", {"x": 1}, ALL)', 'extra-1');
     func('("a", {"x": 1}, CONTAINS)', 'extra-2');
     func('("a", {"x": 1}, [CONTAINS, ALL])', 'extra-3');
+
+    // object-path
+    func('("a", {"x"."y": "1"})', 'object-path-1');
+    func('("a", {"x"."y": "1", "z": 3})', 'object-path-2');
 }
 
 function checkWaitForCount(x, func) {
@@ -2221,6 +2225,10 @@ function checkWaitForObjectProperty(x, func) {
     func('({"a": null}, [STARTS_WITH])', 'extra-3');
     func('({"a": "b"}, [STARTS_WITH, ENDS_WITH])', 'extra-4');
     func('({"a": "b", "c": null}, [STARTS_WITH, ENDS_WITH])', 'extra-5');
+
+    // object-path
+    func('{"x"."y": "1"}', 'object-path-1');
+    func('{"x"."y": "1", "z": 3}', 'object-path-2');
 }
 
 function checkWaitForLocalStorage(x, func) {


### PR DESCRIPTION
Part of https://github.com/GuillaumeGomez/browser-UI-test/issues/559.