### PR TITLE
Add `-display-format` and `--filter` CLI options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -186,9 +186,9 @@ async function runInstruction(loadedInstruction, pages, extras) {
 }
 
 async function runAllCommands(loaded, logs, options, browser) {
-    logs.info(loaded['file'] + '... ');
     const context_parser = loaded['parser'];
     const currentFile = getFileInfo(context_parser);
+    logs.startTest(loaded['file']);
 
     let notOk = false;
     let returnValue = Status.Ok;
@@ -568,7 +568,7 @@ async function innerRunTests(logs, options, browser) {
         && options.getFailureFolder() === ''
         && options.getImageFolder() === ''
     ) {
-        logs.warn({}, 'No failure or image folder set, taking first test file\'s folder');
+        print('[WARNING] No failure or image folder set, taking first test file\'s folder');
         options.testFolder = path.dirname(options.testFiles[0]);
     }
     if (checkFolders(options) === false) {
@@ -680,7 +680,7 @@ async function innerRunTestCode(
         if (loaded === null) {
             return [logs, 1];
         } else if (loaded.parser.get_parser_errors().length !== 0) {
-            logs.info(getFileInfo(loaded.parser), testName + '... ');
+            logs.startTest(testName);
             for (const error of loaded.parser.get_parser_errors()) {
                 logs.error(
                     getFileInfo(loaded.parser, error.line),

--- a/src/index.js
+++ b/src/index.js
@@ -10,13 +10,15 @@ const {
     add_warning,
     loadPuppeteer,
     getFileInfo,
+    getFileInfoFromPath,
     extractFileNameWithoutExtension,
 } = require('./utils.js');
+const consts = require('./consts.js');
 const { Options } = require('./options.js');
 const { Logs } = require('./logs.js');
+const { EOL } = require('os');
 const process = require('process');
 const path = require('path');
-const consts = require('./consts.js');
 const Module = require('module');
 const readline = require('readline-sync');
 
@@ -185,7 +187,7 @@ async function runInstruction(loadedInstruction, pages, extras) {
 
 async function runAllCommands(loaded, logs, options, browser) {
     const currentFile = {'file': loaded['file']};
-    logs.display(loaded['file'] + '... ');
+    logs.info(loaded['file'] + '... ');
     const context_parser = loaded['parser'];
 
     let notOk = false;
@@ -280,7 +282,7 @@ async function runAllCommands(loaded, logs, options, browser) {
                 return false;
             }
             logs.error(getFileInfo(context_parser, line_number, false), `${message}: ` +
-                extras[field].join('\n'));
+                extras[field].join(EOL));
             // We empty the errors to prevent having it duplicated.
             extras[field].splice(0, extras[field].length);
             return true;
@@ -299,20 +301,23 @@ async function runAllCommands(loaded, logs, options, browser) {
             const command = context_parser.get_next_command(pages);
             if (command === null) {
                 if (nb_commands === 0) {
-                    logs.failure(currentFile, 'No command to execute');
+                    logs.failure(getFileInfo(context_parser), 'No command to execute');
                     return Status.Failure;
                 }
                 break;
             }
+            // `line_number` is declared outside of the loop because it's used in the closures
+            // above.
+            line_number = command['line'];
+            const fileInfo = getFileInfo(context_parser, line_number);
             if (command['warnings'] !== undefined) {
-                const fileInfo = getFileInfo(context_parser, command['line']);
                 for (const warning of command['warnings']) {
                     logs.warn(fileInfo, warning);
                 }
             }
             // FIXME: This is ugly to have both 'error' and 'errors'. Clean that up!
             if (command['error'] !== undefined) {
-                logs.error(getFileInfo(context_parser, command['line']), command['error']);
+                logs.error(fileInfo, command['error']);
                 break;
             } else if (command['errors'] !== undefined && command['errors'].length > 0) {
                 for (const error of command['errors']) {
@@ -329,18 +334,16 @@ async function runAllCommands(loaded, logs, options, browser) {
             //
             // (It is needed because we cannot break from inside the `await.catch`.)
             let stopLoop = false;
-            line_number = command['line'];
             const instructions = command['instructions'];
             let stopInnerLoop = false;
 
             for (const instruction of instructions) {
-                const fileInfo = getFileInfo(context_parser, line_number);
                 logs.debug(fileInfo, `EXECUTING (line ${line_number.line}) "${instruction}"`);
                 let loadedInstruction;
                 try {
                     loadedInstruction = loadContent(instruction);
                 } catch (error) { // parsing error
-                    logs.error(fileInfo, `output:\n${error.message}`);
+                    logs.error(fileInfo, `output:${EOL}}${error.message}`);
                     logs.debug(
                         fileInfo,
                         `command \`${command['original']}\` failed on \`${instruction}\``,
@@ -351,15 +354,11 @@ async function runAllCommands(loaded, logs, options, browser) {
                     await runInstruction(loadedInstruction, pages, extras);
                 } catch (err) { // execution error
                     if (err === COLOR_CHECK_ERROR) {
-                        logs.error(
-                            getFileInfo(context_parser, line_number),
-                            err,
-                        );
+                        logs.error(fileInfo, err);
                         stopLoop = true;
                     } else {
                         failed = true;
                         const s_err = err.toString();
-                        const fileInfo = getFileInfo(context_parser, line_number);
                         if (extras.expectedToFail !== true) {
                             const original = command['original'];
                             logs.error(fileInfo, `${s_err}: for command \`${original}\``);
@@ -373,7 +372,7 @@ async function runAllCommands(loaded, logs, options, browser) {
                         }
                     }
                 }
-                logs.debug(currentFile, 'Done!');
+                logs.debug(fileInfo, 'Done!');
                 if (stopLoop || checkJsErrors() || checkRequestErrors()) {
                     break command_loop;
                 } else if (stopInnerLoop) {
@@ -391,7 +390,7 @@ async function runAllCommands(loaded, logs, options, browser) {
                 && extras.expectedToFail === true
             ) {
                 logs.error(
-                    getFileInfo(context_parser, line_number),
+                    fileInfo,
                     `command \`${command['original']}\` was supposed to fail but succeeded`,
                 );
             }
@@ -404,7 +403,7 @@ async function runAllCommands(loaded, logs, options, browser) {
                 shouldWait = true;
             }
             if (command['infos'] !== undefined) {
-                logs.info(getFileInfo(context_parser, line_number), command['infos']);
+                logs.info(fileInfo, command['infos']);
             }
             if (shouldWait) {
                 // We wait a bit between each command to be sure the browser can follow.
@@ -444,7 +443,7 @@ async function runAllCommands(loaded, logs, options, browser) {
             }
             selector = parser.getSelector(extras.screenshotComparison);
             if (selector.error !== undefined) {
-                logs.failure(currentFile, `Cannot take screenshot: ${selector.error.join('\n')}`);
+                logs.failure(currentFile, `Cannot take screenshot: ${selector.error.join(EOL)}`);
                 await page.close();
                 return Status.MissingElementForScreenshot;
             }
@@ -501,9 +500,9 @@ async function runAllCommands(loaded, logs, options, browser) {
         }
     } catch (err) {
         logs.failure(currentFile, '');
-        let msg = loaded['file'] + ' output:\n' + err.message + '\n';
+        let msg = `${loaded['file']} output:${EOL}${err.message}${EOL}`;
         if (err.stack !== undefined) {
-            msg += `stack: ${err.stack}\n`;
+            msg += `stack: ${err.stack}${EOL}`;
         }
         logs.error(currentFile, msg);
         notOk = true;
@@ -553,7 +552,7 @@ async function innerRunTests(logs, options, browser) {
         && options.getFailureFolder() === ''
         && options.getImageFolder() === ''
     ) {
-        print('[WARNING] No failure or image folder set, taking first test file\'s folder');
+        logs.warn({}, 'No failure or image folder set, taking first test file\'s folder');
         options.testFolder = path.dirname(options.testFiles[0]);
     }
     if (checkFolders(options) === false) {
@@ -571,6 +570,8 @@ async function innerRunTests(logs, options, browser) {
         }
         return 0;
     });
+
+    logs.setNbTests(allFiles.length);
 
     process.setMaxListeners(options.nbThreads + 1);
     try {
@@ -596,6 +597,7 @@ async function innerRunTests(logs, options, browser) {
                 browser,
                 false,
                 false,
+                { logs: logs.shallowClone() },
             ).then(out => {
                 const [output, nbFailures] = out;
                 logs.appendLogs(output);
@@ -603,7 +605,7 @@ async function innerRunTests(logs, options, browser) {
                     successes += 1;
                 }
             }).catch(err => {
-                logs.error({'file': testName, err});
+                logs.error(getFileInfoFromPath(testName), err);
             }).finally(() => {
                 // We now remove the promise from the testsQueue.
                 testsQueue.splice(testsQueue.indexOf(callback), 1);
@@ -623,14 +625,14 @@ async function innerRunTests(logs, options, browser) {
 
         let extra = '';
         if (!options.isJsonOutput()) {
-            extra = '\n';
+            extra = EOL;
         }
-        logs.display(
+        logs.conclude(
             `${extra}<= doc-ui tests done: ${successes} succeeded, ${total - successes} \
 failed${extra}`);
     } catch (error) {
-        logs.display(`An exception occured: ${error.message}\n== STACKTRACE ==\n` +
-            `${new Error().stack}\n`);
+        logs.conclude(`An exception occured: ${error.message}${EOL}== STACKTRACE ==${EOL}` +
+            `${new Error().stack}${EOL}`);
         return 1;
     }
 
@@ -644,9 +646,14 @@ async function innerRunTestCode(
     browser,
     showLogs,
     checkTestFolder,
-    content = null,
+    {
+        content = null,
+        logs = null,
+    } = {},
 ) {
-    const logs = new Logs(showLogs, options);
+    if (logs === null) {
+        logs = new Logs(showLogs, options);
+    }
 
     if (checkTestFolder === true && options.testFolder.length > 0) {
         logs.warn({}, '`--test-folder` option will be ignored.');
@@ -657,14 +664,14 @@ async function innerRunTestCode(
         if (loaded === null) {
             return [logs, 1];
         } else if (loaded.parser.get_parser_errors().length !== 0) {
-            logs.display(testName + '... ');
+            logs.info(getFileInfo(loaded.parser), testName + '... ');
             for (const error of loaded.parser.get_parser_errors()) {
                 logs.error(
                     getFileInfo(loaded.parser, error.line),
                     error.message,
                 );
             }
-            logs.failure({'file': testName}, '');
+            logs.failure(getFileInfo(loaded.parser), '');
             return [logs, 1];
         }
 
@@ -684,7 +691,7 @@ async function innerRunTestCode(
     } catch (error) {
         logs.error(
             {'file': testName},
-            `An exception occured: ${error.message}\n== STACKTRACE ==\n${error.stack}`,
+            `An exception occured: ${error.message}${EOL}== STACKTRACE ==${EOL}${error.stack}`,
         );
         return [logs, 1];
     }
@@ -743,7 +750,7 @@ async function runTestCode(testName, content, extras = null) {
     const [browser, options, showLogs] = checkExtras(extras);
 
     const [logs, exit_code] = await innerRunTestCode(
-        testName, '', options, browser, showLogs, true, content);
+        testName, '', options, browser, showLogs, true, { content });
     return [logs.getLogsInExpectedFormat(), exit_code];
 }
 
@@ -812,8 +819,9 @@ async function runTests(extras = null) {
             logs.clear();
             logs.display(error.message);
         } else {
-            logs.display(
-                `An exception occured: ${error.message}\n== STACKTRACE ==\n${new Error().stack}\n`);
+            logs.conclude(
+                `An exception occured: ${error.message}${EOL}== STACKTRACE ==${EOL}` +
+                `${new Error().stack}${EOL}`);
         }
         return [logs.getLogsInExpectedFormat(), 1];
     }

--- a/src/index.js
+++ b/src/index.js
@@ -766,7 +766,7 @@ async function runTestCode(testName, content, extras = null) {
     const [browser, options, showLogs] = checkExtras(extras);
 
     const [logs, exit_code] = await innerRunTestCode(
-        testName, '', options, browser, showLogs, true, { content });
+        testName, null, options, browser, showLogs, true, { content });
     return [logs.getLogsInExpectedFormat(), exit_code];
 }
 

--- a/src/logs.js
+++ b/src/logs.js
@@ -1,4 +1,5 @@
 const process = require('process');
+const { EOL } = require('os');
 
 function convertMessageFromJson(message) {
     const lineInfo = message.is_line_exact ? 'line' : 'around line';
@@ -7,15 +8,16 @@ function convertMessageFromJson(message) {
         lineDisplay += `${lineInfo} ${message.line.line}`;
         if (Array.isArray(message.line.backtrace)) {
             for (const msg of message.line.backtrace) {
-                lineDisplay += `\n    from \`${msg.file}\` line ${msg.line}`;
+                lineDisplay += `${EOL}    from \`${msg.file}\` line ${msg.line}`;
             }
         }
     }
-    const fileDisplay = message.file !== null && message.file !== undefined
-        ? `${message.file}${lineDisplay}: `
-        : '';
+    const fileDisplay =
+        message.file !== null && message.file !== undefined && message.showFile !== false
+            ? `\`${message.file}\` ${lineDisplay}: `
+            : '';
     const levelDisplay = message.showLogLevel !== false ? `[${message.level.toUpperCase()}] ` : '';
-    return `${levelDisplay}${fileDisplay}${message.message}\n`;
+    return `${levelDisplay}${fileDisplay}${message.message}${EOL}`;
 }
 
 function convertMessagesFromJson(messages) {
@@ -24,20 +26,38 @@ function convertMessagesFromJson(messages) {
 
 class Logs {
     constructor(showLogs, options) {
+        this.logs = [];
         this.showLogs = showLogs;
-        if (options === undefined) {
-            this.jsonOutput = false;
-            this.showDebug = false;
-        } else {
+        this.jsonOutput = false;
+        this.showDebug = false;
+        this.displayCompact = false;
+        this.nbTests = null;
+        this.ranTests = [];
+
+        if (options !== undefined) {
             this.jsonOutput = options.isJsonOutput();
             this.showDebug = options.debug;
+            if (!this.jsonOutput) {
+                this.displayCompact = options.isCompactDisplay();
+            }
         }
-        this.logs = [];
+    }
+
+    shallowClone() {
+        const ret = new Logs(this.showLogs);
+
+        ret.jsonOutput = this.jsonOutput;
+        ret.showDebug = this.showDebug;
+        ret.displayCompact = this.displayCompact;
+        ret.nbTests = this.nbTests;
+        ret.ranTests = this.ranTests;
+
+        return ret;
     }
 
     _addLog(level, fileInfo, newLog) {
         if (Array.isArray(newLog)) {
-            newLog = newLog.join('\n');
+            newLog = newLog.join(EOL);
         }
         if (typeof newLog !== 'string' || newLog.length === 0) {
             return;
@@ -67,8 +87,8 @@ class Logs {
         this.logs.push(newLog);
         if (this.showLogs === true) {
             if (this.jsonOutput) {
-                process.stdout.write(JSON.stringify(newLog) + '\n');
-            } else {
+                process.stdout.write(JSON.stringify(newLog) + EOL);
+            } else if (newLog.ignoreCompact === true || !this.isCompactDisplay()) {
                 process.stdout.write(convertMessageFromJson(newLog));
             }
         }
@@ -102,12 +122,32 @@ class Logs {
 
     clear() {
         this.logs = [];
+        this.nbTests = null;
+    }
+
+    isCompactDisplay() {
+        return this.displayCompact && this.nbTests !== null;
+    }
+
+    displayCompactFileInfo() {
+        process.stdout.write(` (${this.ranTests.length}/${this.nbTests})${EOL}`);
+    }
+
+    updateCompactDisplay(file, success) {
+        if (this.isCompactDisplay()) {
+            process.stdout.write(success ? '.' : 'F');
+            this.ranTests.push(file);
+            if (this.ranTests.length % 50 === 0) {
+                this.displayCompactFileInfo();
+            }
+        }
     }
 
     failure(fileInfo, message) {
         const msg = message.length > 0 ? `FAILED (${message})` : 'FAILED';
         if (!this.jsonOutput) {
-            fileInfo.file = null;
+            this.updateCompactDisplay(fileInfo.file, false);
+            fileInfo.showFile = false;
         }
         fileInfo.showLogLevel = false;
         this.error(fileInfo, msg);
@@ -125,7 +165,8 @@ class Logs {
 
     success(fileInfo, message) {
         if (!this.jsonOutput) {
-            fileInfo.file = null;
+            this.updateCompactDisplay(fileInfo.file, true);
+            fileInfo.showFile = false;
         }
         fileInfo.showLogLevel = false;
         this.info(fileInfo, message);
@@ -146,6 +187,7 @@ class Logs {
             'message': message,
             'level': 'info',
             'showLogLevel': false,
+            'ignoreCompact': true,
         });
     }
 
@@ -176,6 +218,36 @@ class Logs {
     // returns a string.
     getLogsInExpectedFormat() {
         return this.jsonOutput ? this.logs : convertMessagesFromJson(this.logs);
+    }
+
+    setNbTests(nbTests) {
+        this.nbTests = nbTests;
+        if (this.isCompactDisplay()) {
+            process.stdout.write(EOL);
+        }
+    }
+
+    conclude(message) {
+        if (this.isCompactDisplay()) {
+            let s = '';
+            for (let i = this.ranTests.length % 50; i < 50; ++i) {
+                s += ' ';
+            }
+            process.stdout.write(s);
+            this.displayCompactFileInfo();
+            process.stdout.write(EOL);
+
+            // Now we display logs that might need to be displayed, like warnings and errors.
+            for (const test of this.ranTests) {
+                const messages = this.logs.filter(log => log.file === test && log.level !== 'info');
+                if (messages.length !== 0) {
+                    process.stdout.write(`======== ${test} ========${EOL}${EOL}`);
+                    process.stdout.write(convertMessagesFromJson(messages));
+                    process.stdout.write(EOL);
+                }
+            }
+        }
+        this.display(message);
     }
 }
 

--- a/src/logs.js
+++ b/src/logs.js
@@ -5,19 +5,21 @@ function convertMessageFromJson(message) {
     const lineInfo = message.is_line_exact ? 'line' : 'around line';
     let lineDisplay = '';
     if (message.line !== null && message.line !== undefined) {
-        lineDisplay += ` ${lineInfo} ${message.line.line}`;
+        lineDisplay += `${lineInfo} ${message.line.line}`;
         if (Array.isArray(message.line.backtrace)) {
             for (const msg of message.line.backtrace) {
                 lineDisplay += `${EOL}    from \`${msg.file}\` line ${msg.line}`;
             }
         }
+        lineDisplay += ': ';
     }
     const fileDisplay =
-        message.file !== null && message.file !== undefined && message.showFile !== false
-            ? `\`${message.file}\`${lineDisplay}: `
+        message.file !== null && message.file !== undefined && message.file !== '' &&
+            message.showFile !== false
+            ? `\`${message.file}\` `
             : '';
     const levelDisplay = message.showLogLevel !== false ? `[${message.level.toUpperCase()}] ` : '';
-    return `${levelDisplay}${fileDisplay}${message.message}${EOL}`;
+    return `${levelDisplay}${fileDisplay}${lineDisplay}${message.message}${EOL}`;
 }
 
 function convertMessagesFromJson(messages) {

--- a/src/logs.js
+++ b/src/logs.js
@@ -5,7 +5,7 @@ function convertMessageFromJson(message) {
     const lineInfo = message.is_line_exact ? 'line' : 'around line';
     let lineDisplay = '';
     if (message.line !== null && message.line !== undefined) {
-        lineDisplay += `${lineInfo} ${message.line.line}`;
+        lineDisplay += ` ${lineInfo} ${message.line.line}`;
         if (Array.isArray(message.line.backtrace)) {
             for (const msg of message.line.backtrace) {
                 lineDisplay += `${EOL}    from \`${msg.file}\` line ${msg.line}`;
@@ -14,7 +14,7 @@ function convertMessageFromJson(message) {
     }
     const fileDisplay =
         message.file !== null && message.file !== undefined && message.showFile !== false
-            ? `\`${message.file}\` ${lineDisplay}: `
+            ? `\`${message.file}\`${lineDisplay}: `
             : '';
     const levelDisplay = message.showLogLevel !== false ? `[${message.level.toUpperCase()}] ` : '';
     return `${levelDisplay}${fileDisplay}${message.message}${EOL}`;
@@ -139,6 +139,13 @@ class Logs {
             this.ranTests.push(file);
             if (this.ranTests.length % 50 === 0) {
                 this.displayCompactFileInfo();
+            } else if (this.ranTests.length === this.nbTests) {
+                let s = '';
+                for (let i = this.ranTests.length % 50; i < 50; ++i) {
+                    s += ' ';
+                }
+                process.stdout.write(s);
+                this.displayCompactFileInfo();
             }
         }
     }
@@ -179,6 +186,12 @@ class Logs {
                     break;
                 }
             }
+        }
+    }
+
+    startTest(testName) {
+        if (!this.isCompactDisplay()) {
+            this.display(testName + '... ');
         }
     }
 
@@ -229,12 +242,6 @@ class Logs {
 
     conclude(message) {
         if (this.isCompactDisplay()) {
-            let s = '';
-            for (let i = this.ranTests.length % 50; i < 50; ++i) {
-                s += ' ';
-            }
-            process.stdout.write(s);
-            this.displayCompactFileInfo();
             process.stdout.write(EOL);
 
             this.ranTests.sort();

--- a/src/logs.js
+++ b/src/logs.js
@@ -237,6 +237,8 @@ class Logs {
             this.displayCompactFileInfo();
             process.stdout.write(EOL);
 
+            this.ranTests.sort();
+
             // Now we display logs that might need to be displayed, like warnings and errors.
             for (const test of this.ranTests) {
                 const messages = this.logs.filter(log => log.file === test && log.level !== 'info');

--- a/src/options.js
+++ b/src/options.js
@@ -120,7 +120,7 @@ class Options {
         copy.nbThreads = this.nbThreads;
         copy.messageFormat = this.messageFormat.slice();
         copy.displayFormat = this.displayFormat.slice();
-        copy.filter = this.filter.slice();
+        copy.filter = this.filter !== null ? this.filter.slice() : null;
         return copy;
     }
 

--- a/src/options.js
+++ b/src/options.js
@@ -152,8 +152,8 @@ class Options {
             if (accepted !== undefined) {
                 if (!accepted.includes(arg)) {
                     const s = accepted.map(a => `\`${a}\``).join(' or ');
-                    throw new Error(`\`${name}\` option only accepts ${s} as value, found ` +
-                        `\`${arg}\``);
+                    throw new Error(`\`${args[it - 1]}\` option only accepts ${s} as value, found` +
+                        ` \`${arg}\``);
                 }
             }
             return arg;

--- a/src/options.js
+++ b/src/options.js
@@ -77,6 +77,7 @@ class Options {
         this.screenshotOnFailure = false;
         this.nbThreads = os.cpus().length;
         this.messageFormat = 'human';
+        this.displayFormat = 'normal';
         // Enabled by default!
         this.failOnRequestError = true;
         this.executablePath = null;
@@ -117,6 +118,7 @@ class Options {
         copy.screenshotOnFailure = this.screenshotOnFailure;
         copy.nbThreads = this.nbThreads;
         copy.messageFormat = this.messageFormat.slice();
+        copy.displayFormat = this.displayFormat.slice();
         return copy;
     }
 
@@ -139,12 +141,20 @@ class Options {
                 throw new Error(`Missing path after \`${args[it]}\` option`);
             }
         };
-        const oneArg = name => {
+        const oneArg = (name, accepted) => {
             if (it + 1 >= args.length) {
                 throw new Error(`Missing ${name} after \`${args[it]}\` option`);
             }
             it += 1;
-            return args[it];
+            const arg = args[it].trim();
+            if (accepted !== undefined) {
+                if (!accepted.includes(arg)) {
+                    const s = accepted.map(a => `\`${a}\``).join(' or ');
+                    throw new Error(`\`${name}\` option only accepts ${s} as value, found ` +
+                        `\`${arg}\``);
+                }
+            }
+            return arg;
         };
         const twoArgs = name => {
             if (it + 2 < args.length) {
@@ -170,13 +180,7 @@ class Options {
                     ' is stable!',
                 'extra': '[BROWSER NAME]',
                 'handler': () => {
-                    const browser = oneArg('browser name').trim();
-                    if (BROWSERS.indexOf(browser) === -1) {
-                        const browsers = BROWSERS.map(e => `"${e}"`).join(' or ');
-                        throw new Error(`\`--browser\` option only accepts ${browsers} as values,` +
-                            ` found \`${browser}\``);
-                    }
-                    this.browser = browser;
+                    this.browser = oneArg('browser name', BROWSERS);
                 },
             }],
             ['--debug', {
@@ -286,27 +290,26 @@ class Options {
                     this.headless = false;
                 },
             }],
+            ['--display-format', {
+                'help': 'If tests should display all information or just the minimum (like ' +
+                    'warnings and errors)',
+                'extra': '[normal|compact]',
+                'handler': () => {
+                    this.displayFormat = oneArg('display format', ['normal', 'compact']);
+                },
+            }],
             ['--message-format', {
                 'help': 'In which format the messages (like errors) should be emitted',
                 'extra': '[human|json]',
                 'handler': () => {
-                    const format = oneArg('message format').trim();
-                    if (!['human', 'json'].includes(format)) {
-                        throw new Error(`\`--message-format\` option only accepts \`human\` or \
-                            \`json\` as values, found \`${format}\``);
-                    }
-                    this.messageFormat = format;
+                    this.messageFormat = oneArg('message format', ['human', 'json']);
                 },
             }],
             ['--pause-on-error', {
                 'help': 'Pause execution script until user press ENTER',
                 'extra': '[true|false]',
                 'handler': () => {
-                    this.pauseOnError = oneArg('`true` or `false`');
-                    if (['true', 'false'].indexOf(this.pauseOnError) === -1) {
-                        throw new Error('`--pause-on-error` can only be `true` or `false`!');
-                    }
-                    this.pauseOnError = this.pauseOnError === 'true';
+                    this.pauseOnError = oneArg('`true` or `false`', ['true', 'false']) === 'true';
                 },
             }],
             ['--permission', {
@@ -468,6 +471,10 @@ class Options {
         return this.messageFormat === 'json';
     }
 
+    isCompactDisplay() {
+        return this.displayFormat === 'compact';
+    }
+
     validateFields() {
         // Check if variables have the expected types (you never know...).
         const validateField = (fieldName, expectedType) => {
@@ -504,6 +511,7 @@ class Options {
         validateField('screenshotOnFailure', 'boolean');
         validateField('nbThreads', 'number');
         validateField('messageFormat', 'string');
+        validateField('displayFormat', 'string');
         if (!(this.variables instanceof Map)) {
             throw new Error('`Options.variables` field is supposed to be a `Map`! ' +
                 `(Type is ${typeof this.variables})`);

--- a/src/options.js
+++ b/src/options.js
@@ -78,6 +78,7 @@ class Options {
         this.nbThreads = os.cpus().length;
         this.messageFormat = 'human';
         this.displayFormat = 'normal';
+        this.filter = null;
         // Enabled by default!
         this.failOnRequestError = true;
         this.executablePath = null;
@@ -119,6 +120,7 @@ class Options {
         copy.nbThreads = this.nbThreads;
         copy.messageFormat = this.messageFormat.slice();
         copy.displayFormat = this.displayFormat.slice();
+        copy.filter = this.filter.slice();
         return copy;
     }
 
@@ -249,6 +251,13 @@ class Options {
                     '`image-folder` if not provided)',
                 'extra': '[PATH]',
                 'handler': addPath,
+            }],
+            ['--filter', {
+                'help': 'Only run test with the provided filter is in their file name',
+                'extra': '[NAME]',
+                'handler': () => {
+                    this.filter = oneArg('filter');
+                },
             }],
             ['--generate-images', {
                 'help': 'If provided, it\'ll generate missing test images',

--- a/src/utils.js
+++ b/src/utils.js
@@ -181,14 +181,17 @@ function hasError(x) {
     return x.error !== undefined && x.error !== null;
 }
 
-function getFileInfo(context_parser, line, isExact = true) {
-    const file = stripCommonPathsPrefix(context_parser.getCurrentFile());
-    const file_s = file.length > 0 ? `\`${file}\` ` : '';
+function getFileInfoFromPath(path, line = null, isExact = true) {
+    const file = stripCommonPathsPrefix(path);
     return {
-        'file': file_s,
+        'file': file,
         'line': line,
         'is_line_exact': isExact,
     };
+}
+
+function getFileInfo(context_parser, line = null, isExact = true) {
+    return getFileInfoFromPath(context_parser.getCurrentFile(), line, isExact);
 }
 
 module.exports = {
@@ -213,5 +216,6 @@ module.exports = {
     'plural': plural,
     'hasError': hasError,
     'getFileInfo': getFileInfo,
+    'getFileInfoFromPath': getFileInfoFromPath,
     'ALLOWED_EMULATE_MEDIA_FEATURES_KEYS': ALLOWED_EMULATE_MEDIA_FEATURES_KEYS,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const config = require('./config.js');
 const path = require('path');
+const { EOL } = require('os');
 const process = require('process');
 const {PuppeteerWrapper} = require('./puppeteer-wrapper.js');
 
@@ -46,7 +47,7 @@ function readFile(filePath, encoding, callback) {
 
 function print(s, backline = true) {
     if (typeof s === 'string') {
-        process.stdout.write(`${s}${backline === true ? '\n' : ''}`);
+        process.stdout.write(`${s}${backline === true ? EOL : ''}`);
     }
 }
 

--- a/tests/compact-display/compact-display.output
+++ b/tests/compact-display/compact-display.output
@@ -1,0 +1,24 @@
+=> Starting doc-ui tests...
+
+FFFF                                               (4/4)
+
+======== tests/ui/assert-clipboard-2.goml ========
+
+[ERROR] `tests/ui/assert-clipboard-2.goml` line 6: Error: The following checks still fail: [`hello` isn't equal to `hell`]: for command `wait-for-clipboard: "hell"`
+
+======== tests/ui/assert-clipboard.goml ========
+
+[ERROR] `tests/ui/assert-clipboard.goml` line 21: Error: All checks still succeed: for command `wait-for-clipboard-false: "hello"`
+
+======== tests/ui/assert-css-color.goml ========
+
+[ERROR] `tests/ui/assert-css-color.goml` line 8: `show-text: true` needs to be used before checking for `color` (otherwise the browser doesn't compute it)
+
+======== tests/ui/assert-css.goml ========
+
+[ERROR] `tests/ui/assert-css.goml` line 4: The following errors happened (for selector `.content>.left>p`): [expected `white` for key `color`, found `whitesmoke`]: for command `assert-css: (".content>.left>p", {"color": "white"})`
+[ERROR] `tests/ui/assert-css.goml` line 6: The following errors happened (for selector `.content>.right>p`): [expected `white` for key `color`, found `rgb(244, 245, 245)`]: for command `assert-css: (".content>.right>p", {"color": "white"})`
+
+
+<= doc-ui tests done: 0 succeeded, 4 failed, 81 filtered out
+

--- a/tests/ui/assert-clipboard-2.output
+++ b/tests/ui/assert-clipboard-2.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 assert-clipboard-2... 
 [ERROR] `tests/ui/assert-clipboard-2.goml` line 6: Error: The following checks still fail: [`hello` isn't equal to `hell`]: for command `wait-for-clipboard: "hell"`
-assert-clipboard-2: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/assert-clipboard-2.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/assert-clipboard.output
+++ b/tests/ui/assert-clipboard.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 assert-clipboard... 
 [ERROR] `tests/ui/assert-clipboard.goml` line 21: Error: All checks still succeed: for command `wait-for-clipboard-false: "hello"`
-assert-clipboard: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/assert-clipboard.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/assert-css-color.output
+++ b/tests/ui/assert-css-color.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 assert-css-color... 
 [ERROR] `tests/ui/assert-css-color.goml` line 8: `show-text: true` needs to be used before checking for `color` (otherwise the browser doesn't compute it)
-assert-css-color: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/assert-css-color.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/assert-css.output
+++ b/tests/ui/assert-css.output
@@ -2,5 +2,5 @@
 assert-css... 
 [ERROR] `tests/ui/assert-css.goml` line 4: The following errors happened (for selector `.content>.left>p`): [expected `white` for key `color`, found `whitesmoke`]: for command `assert-css: (".content>.left>p", {"color": "white"})`
 [ERROR] `tests/ui/assert-css.goml` line 6: The following errors happened (for selector `.content>.right>p`): [expected `white` for key `color`, found `rgb(244, 245, 245)`]: for command `assert-css: (".content>.right>p", {"color": "white"})`
-assert-css: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/assert-css.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/assert-expr.output
+++ b/tests/ui/assert-expr.output
@@ -7,5 +7,5 @@ assert-expr...
 [ERROR] `tests/ui/assert-expr.goml` line 31: Condition `{"b": 3} == |var3|` (`compareJson({"b": 3}, {"a": 2})`) was evaluated as false: for command `assert: {"b": 3} == |var3|`
 [ERROR] `tests/ui/assert-expr.goml` line 33: Condition `(1, "a") == (2, 3)` (`compareArrayLike([1, "a"], [2, 3])`) was evaluated as false: for command `assert: (1, "a") == (2, 3)`
 [ERROR] `tests/ui/assert-expr.goml` line 35: Condition `[1, 2] == ["a", "b"]` (`compareArrayLike([1, 2], ["a", "b"])`) was evaluated as false: for command `assert: [1, 2] == ["a", "b"]`
-assert-expr: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/assert-expr.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/assert-find-text.output
+++ b/tests/ui/assert-find-text.output
@@ -2,5 +2,5 @@
 assert-find-text... 
 [ERROR] `tests/ui/assert-find-text.goml` line 9: Error: Didn't find text `another`: for command `assert-find-text: ("another", {"case-sensitive": true})`
 [ERROR] `tests/ui/assert-find-text.goml` line 11: Error: Found text `Another`: for command `assert-find-text-false: ("Another", {"case-sensitive": true})`
-assert-find-text: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/assert-find-text.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/assert-local-storage.output
+++ b/tests/ui/assert-local-storage.output
@@ -4,5 +4,5 @@ assert-local-storage...
 [ERROR] `tests/ui/assert-local-storage.goml` line 7: The following errors happened: [localStorage item "something" (of value "whatever") != "hello"]: for command `assert-local-storage: {"something": "whatever"}`
 [ERROR] `tests/ui/assert-local-storage.goml` line 10: The following errors happened: [localStorage item "something" (of value "hello") == "hello"]: for command `assert-local-storage-false: {"something": "hello"}`
 [ERROR] `tests/ui/assert-local-storage.goml` line 14: The following errors happened: [localStorage item "other" (of value "hehe") != "null"]: for command `assert-local-storage: {"something": "whatever", "other": "hehe"}`
-assert-local-storage: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/assert-local-storage.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/assert-null.output
+++ b/tests/ui/assert-null.output
@@ -12,5 +12,5 @@ assert-null...
 [ERROR] `tests/ui/assert-null.goml` line 56: The following errors happened: [Expected property `"bgColor"` to not exist, found: ``]: for command `assert-document-property: {"bgColor": null}`
 [ERROR] `tests/ui/assert-null.goml` line 59: The following errors happened: [Property named `"yolo"` doesn't exist]: for command `assert-document-property-false: {"yolo": null}`
 [WARNING] `tests/ui/assert-null.goml` line 63: Special checks (CONTAINS) will be ignored for `null`
-assert-null: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/assert-null.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/assert-position.output
+++ b/tests/ui/assert-position.output
@@ -4,5 +4,5 @@ assert-position...
 [ERROR] `tests/ui/assert-position.goml` line 5: The following errors happened: [different X values: 0 (or 0) != 1; different Y values: 24 (or 24) != 2]: for command `assert-position: ("#the-input", {"x": 1, "y": 2})`
 [ERROR] `tests/ui/assert-position.goml` line 8: The following errors happened: [same X values (whereas it shouldn't): 0 (or 0) != 0]: for command `assert-position-false: ("#the-input", {"x": 0, "y": 29})`
 [ERROR] `tests/ui/assert-position.goml` line 11: The following errors happened: [different X values: 0 (or 0) != 1; different Y values: 24 (or 24) != 2]: for command `assert-position: ("#the-input::after", {"x": 1, "y": 2})`
-assert-position: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/assert-position.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/assert-size.output
+++ b/tests/ui/assert-size.output
@@ -3,5 +3,5 @@ assert-size...
 [ERROR] `tests/ui/assert-size.goml` line 4: The following errors happened: [expected a height of `650`, found `24`]: for command `assert-size: ("header", {"width": 670, "height": 650})`
 [ERROR] `tests/ui/assert-size.goml` line 8: The following errors happened: [width is equal to `670`; height is equal to `24`]: for command `assert-size-false: ("header", {"width": 670, "height": 24})`
 [ERROR] `tests/ui/assert-size.goml` line 13: The following errors happened: [expected a width of `670`, found `38`] (on the element number 0): for command `assert-size: ("button", {"width": 670, "height": 21}, ALL)`
-assert-size: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/assert-size.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/assert-variable.output
+++ b/tests/ui/assert-variable.output
@@ -3,5 +3,5 @@ assert-variable...
 [ERROR] `tests/ui/assert-variable.goml` line 5: The following errors happened: [`hello` is not a number (for NEAR check)]: for command `assert-variable: (variable_name, 10, NEAR)`
 [ERROR] `tests/ui/assert-variable.goml` line 10: The following errors happened: [`10` is within 1 of `9` (for NEAR check)]: for command `assert-variable-false: (variable_name, 9, NEAR)`
 [ERROR] `tests/ui/assert-variable.goml` line 14: The following errors happened: [`10` is not within 1 of `8` (for NEAR check)]: for command `assert-variable: (variable_name, 8, NEAR)`
-assert-variable: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/assert-variable.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/assert-warning.output
+++ b/tests/ui/assert-warning.output
@@ -2,5 +2,5 @@
 assert-warning... 
 [WARNING] `tests/ui/assert-warning.goml` line 3: Pseudo-elements (`::after`) don't have attributes so the check will be performed on the element itself
 [WARNING] `tests/ui/assert-warning.goml` line 5: Pseudo-elements (`::after`) don't have properties so the check will be performed on the element itself
-assert-warning: OK
-<= doc-ui tests done: 1 succeeded, 0 failed
+`tests/ui/assert-warning.goml` OK
+<= doc-ui tests done: 1 succeeded, 0 failed, 0 filtered out

--- a/tests/ui/asserts.output
+++ b/tests/ui/asserts.output
@@ -37,5 +37,5 @@ asserts...
 [ERROR] `tests/ui/asserts.goml` line 111: The following errors happened: [window property `name` (``) is NaN (for NEAR check)]: for command `assert-window-property: ({"name": ".con"}, NEAR)`
 [ERROR] `tests/ui/asserts.goml` line 114: The following errors happened: [window property `length` (`0`) is not within 1 of `999` (for NEAR check)]: for command `assert-window-property: ({"length": 999}, NEAR)`
 [ERROR] `tests/ui/asserts.goml` line 117: `#non-existent` not found: for command `click: "#non-existent"`
-asserts: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/asserts.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/before-goto.output
+++ b/tests/ui/before-goto.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 before-goto... 
 [ERROR] `tests/ui/before-goto.goml` line 2: First command must be `go-to` (`assert-variable`, `assert-variable-false`, `call-function`, `debug`, `define-function`, `emulate`, `emulate-media-features`, `expect-failure`, `fail-on-js-error`, `fail-on-request-error`, `include`, `javascript`, `screenshot-comparison`, `screenshot-on-failure`, `store-value`, `set-timeout` or `set-window-size` can be used before)!
-before-goto: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/before-goto.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/block-network-request-multiple-star.output
+++ b/tests/ui/block-network-request-multiple-star.output
@@ -1,4 +1,4 @@
 => Starting doc-ui tests...
 block-network-request-multiple-star... 
-block-network-request-multiple-star: OK
-<= doc-ui tests done: 1 succeeded, 0 failed
+`tests/ui/block-network-request-multiple-star.goml` OK
+<= doc-ui tests done: 1 succeeded, 0 failed, 0 filtered out

--- a/tests/ui/block-network-request.output
+++ b/tests/ui/block-network-request.output
@@ -1,4 +1,4 @@
 => Starting doc-ui tests...
 block-network-request... 
-block-network-request: OK
-<= doc-ui tests done: 1 succeeded, 0 failed
+`tests/ui/block-network-request.goml` OK
+<= doc-ui tests done: 1 succeeded, 0 failed, 0 filtered out

--- a/tests/ui/call-function-before-goto.output
+++ b/tests/ui/call-function-before-goto.output
@@ -2,5 +2,5 @@
 call-function-before-goto... 
 [ERROR] `tests/ui/call-function-before-goto.goml` line 7
     from `tests/ui/call-function-before-goto.goml` line 23: First command must be `go-to` (`assert-variable`, `assert-variable-false`, `call-function`, `debug`, `define-function`, `emulate`, `emulate-media-features`, `expect-failure`, `fail-on-js-error`, `fail-on-request-error`, `include`, `javascript`, `screenshot-comparison`, `screenshot-on-failure`, `store-value`, `set-timeout` or `set-window-size` can be used before)!
-call-function-before-goto: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/call-function-before-goto.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/click.output
+++ b/tests/ui/click.output
@@ -1,4 +1,4 @@
 => Starting doc-ui tests...
 click... 
-click: OK
-<= doc-ui tests done: 1 succeeded, 0 failed
+`tests/ui/click.goml` OK
+<= doc-ui tests done: 1 succeeded, 0 failed, 0 filtered out

--- a/tests/ui/compare-elements-css-color.output
+++ b/tests/ui/compare-elements-css-color.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 compare-elements-css-color... 
 [ERROR] `tests/ui/compare-elements-css-color.goml` line 4: `show-text: true` needs to be used before checking for `color` (otherwise the browser doesn't compute it)
-compare-elements-css-color: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/compare-elements-css-color.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/compare.output
+++ b/tests/ui/compare.output
@@ -17,5 +17,5 @@ compare...
 [ERROR] `tests/ui/compare.goml` line 58: comparison didn't fail: for command `compare-elements-size-near-false: (".content .right", ".content .left", {"width": 1})`
 [ERROR] `tests/ui/compare.goml` line 60: heights don't match: 14 != 1: for command `compare-elements-size: ("#another-one::before", ".content .left span", ["height"])`
 [ERROR] `tests/ui/compare.goml` line 62: delta for height values too large: 13 > 1: for command `compare-elements-size-near: ("#another-one::before", ".content .left span", {"height": 1})`
-compare: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/compare.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/debug.output
+++ b/tests/ui/debug.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 debug... 
 [ERROR] `tests/ui/debug.goml` line 5: assert didn't fail: for command `compare-elements-css-false: (".content>.right>p", ".content>.left", ["color"])`
-debug: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/debug.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/debug2.output
+++ b/tests/ui/debug2.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 debug2... 
 [ERROR] `tests/ui/debug2.goml` line 6: assert didn't fail: for command `compare-elements-css-false: (".content>.right>p", ".content>.left", ["color"])`
-debug2: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/debug2.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/define-function.output
+++ b/tests/ui/define-function.output
@@ -14,5 +14,5 @@ define-function...
         })
     }
 )`)
-define-function: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/define-function.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/device-pixel-ratio.output
+++ b/tests/ui/device-pixel-ratio.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 device-pixel-ratio... 
 [ERROR] `tests/ui/device-pixel-ratio.goml` line 7: expected numbers above 0, found `-2` (from command `set-device-pixel-ratio: -2`)
-device-pixel-ratio: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/device-pixel-ratio.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/dont-stop-at-first-failure.output
+++ b/tests/ui/dont-stop-at-first-failure.output
@@ -3,5 +3,5 @@ dont-stop-at-first-failure...
 [ERROR] `tests/ui/dont-stop-at-first-failure.goml` line 4: "#doesnt-exist" not found: for command `assert: "#doesnt-exist"`
 [ERROR] `tests/ui/dont-stop-at-first-failure.goml` line 6: The following errors happened (for selector `.content>.right>p`): [expected `200px` for key `font-size`, found `16px`; expected `30` for key `height`, found `18px`]: for command `assert-css: (".content>.right>p", {"font-size": "200px", "height": "30"})`
 [ERROR] `tests/ui/dont-stop-at-first-failure.goml` line 8: The following errors happened (for selector `.content>.right>p`): [assert didn't fail for key `font-size`; assert didn't fail for key `height`]: for command `assert-css-false: (".content>.right>p", {"font-size": "16px", "height": "18px"})`
-dont-stop-at-first-failure: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/dont-stop-at-first-failure.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/emulate.output
+++ b/tests/ui/emulate.output
@@ -1,4 +1,4 @@
 => Starting doc-ui tests...
 emulate... 
-emulate: OK
-<= doc-ui tests done: 1 succeeded, 0 failed
+`tests/ui/emulate.goml` OK
+<= doc-ui tests done: 1 succeeded, 0 failed, 0 filtered out

--- a/tests/ui/error-before-variable-inference.output
+++ b/tests/ui/error-before-variable-inference.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 error-before-variable-inference... 
 [ERROR] `tests/ui/error-before-variable-inference.goml` line 3: Unknown command "whatever"
-error-before-variable-inference: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/error-before-variable-inference.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/error-comments.output
+++ b/tests/ui/error-comments.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 error-comments... 
 [ERROR] `tests/ui/error-comments.goml` line 4: The following errors happened (for selector `body`): [expected `194` for property `"clientWidth"`, found `1000`; expected `200` for property `"offsetWidth"`, found `1000`]: for command `assert-property: ("body", {"clientWidth": "194", "offsetWidth": "200"})`
-error-comments: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/error-comments.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/escapes.output
+++ b/tests/ui/escapes.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 escapes... 
 [ERROR] `tests/ui/escapes.goml` line 22: Cannot navigate to invalid URL `file://C:\a\b\d\elements.html`: for command `go-to: "file://" + |WINDOWS_PATH| + "\\d\\elements.html"`
-escapes: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/escapes.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/fail-on-js-error.output
+++ b/tests/ui/fail-on-js-error.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 fail-on-js-error... 
 [ERROR] `tests/ui/fail-on-js-error.goml` around line 4: JS errors occurred: TypeError: Cannot read properties of null (reading 'hello')
-fail-on-js-error: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/fail-on-js-error.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/function-named-map-extra-argument.output
+++ b/tests/ui/function-named-map-extra-argument.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 function-named-map-extra-argument... 
 [ERROR] `tests/ui/function-named-map-extra-argument.goml` line 14: function `fn1` expected 2 arguments, found 3 (from command `call-function: ("fn1", {"background_color": "a", "whole_check": {"color": "a"}, "k": {"color": "a"}})`)
-function-named-map-extra-argument: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/function-named-map-extra-argument.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/functions-execution.output
+++ b/tests/ui/functions-execution.output
@@ -18,5 +18,5 @@ functions-execution...
     from `tests/ui/functions-execution.goml` line 28: The following errors happened (for selector `header`): [expected `h` for key `background-color`, found `rgb(17, 17, 17)`]: for command `assert-css: ("header", {"background-color": "h"})`
 [ERROR] `tests/ui/functions-execution.goml` line 24
     from `tests/ui/functions-execution.goml` line 28: The following errors happened (for selector `header`): [expected `i` for key `background-color`, found `rgb(17, 17, 17)`]: for command `assert-css: ("header", {"background-color": "i"})`
-functions-execution: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/functions-execution.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/functions.output
+++ b/tests/ui/functions.output
@@ -17,5 +17,5 @@ functions...
 [ERROR] `tests/ui/functions.goml` line 38
     from `tests/ui/functions.goml` line 43: The following errors happened (for selector `header`): [expected `a` for key `color`, found `rgb(255, 255, 255)`]: for command `assert-css: ("header", |whole_check|)`
 [ERROR] `tests/ui/functions.goml` line 45: Missing argument "whole_check" (from command `call-function: ("fn1", {"background_color": "a", "k": {"color": "a"}})`)
-functions: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/functions.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/include.output
+++ b/tests/ui/include.output
@@ -8,5 +8,5 @@ include...
 [ERROR] `tests/ui/include.goml` line 9: The following errors happened: [`` isn't equal to `tadam`]: for command `assert-text: ("header", "tadam")`
 [ERROR] `tests/ui/sub/func.goml` line 5
     from `tests/ui/include.goml` line 14: `#does_not-exist` not found: for command `click: "#does_not-exist"`
-include: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/include.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/json-dict.output
+++ b/tests/ui/json-dict.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 json-dict... 
 [ERROR] `tests/ui/json-dict.goml` line 7: only strings and object-paths can be used as keys in JSON dict, found a number (`1`)
-json-dict: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/json-dict.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/line-number.output
+++ b/tests/ui/line-number.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 line-number... 
 [ERROR] `tests/ui/line-number.goml` line 4: assert didn't fail: for command `compare-elements-css-false: (".content>.right>p", ".content>.left", ["color"])`
-line-number: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/line-number.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/line-number2.output
+++ b/tests/ui/line-number2.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 line-number2... 
 [ERROR] `tests/ui/line-number2.goml` line 5: command `compare-elements-css: (".content>.right>p", ".content>.left", ["color"])` was supposed to fail but succeeded
-line-number2: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/line-number2.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/page-change-in-wait.output
+++ b/tests/ui/page-change-in-wait.output
@@ -1,4 +1,4 @@
 => Starting doc-ui tests...
 page-change-in-wait... 
-page-change-in-wait: OK
-<= doc-ui tests done: 1 succeeded, 0 failed
+`tests/ui/page-change-in-wait.goml` OK
+<= doc-ui tests done: 1 succeeded, 0 failed, 0 filtered out

--- a/tests/ui/parser-errors.output
+++ b/tests/ui/parser-errors.output
@@ -9,5 +9,5 @@ parser-errors...
 [ERROR] `tests/ui/parser-errors.goml` line 10: expected `,` or `)` after `a`, found `b`
 [ERROR] `tests/ui/parser-errors.goml` line 10: expected `,` or `)` after `a`, found `|b`
 [ERROR] `tests/ui/parser-errors.goml` line 10: unexpected character `)` after `|b`
-parser-errors: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/parser-errors.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/property.output
+++ b/tests/ui/property.output
@@ -1,4 +1,4 @@
 => Starting doc-ui tests...
 property... 
-property: OK
-<= doc-ui tests done: 1 succeeded, 0 failed
+`tests/ui/property.goml` OK
+<= doc-ui tests done: 1 succeeded, 0 failed, 0 filtered out

--- a/tests/ui/pseudo-element-selection.output
+++ b/tests/ui/pseudo-element-selection.output
@@ -3,5 +3,5 @@ pseudo-element-selection...
 [ERROR] `tests/ui/pseudo-element-selection.goml` line 5: `#before-1:after` not found: for command `assert-css: ("#before-1:after", {"content": '"a"'})`
 [ERROR] `tests/ui/pseudo-element-selection.goml` line 9: `#before:after` not found: for command `assert-css: ("#before:after", {"content": '"b"'})`
 [ERROR] `tests/ui/pseudo-element-selection.goml` line 13: `#before-:after` not found: for command `assert-css: ("#before-:after", {"content": '"c"'})`
-pseudo-element-selection: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/pseudo-element-selection.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/request-failure-disabled.output
+++ b/tests/ui/request-failure-disabled.output
@@ -1,4 +1,4 @@
 => Starting doc-ui tests...
 request-failure-disabled... 
-request-failure-disabled: OK
-<= doc-ui tests done: 1 succeeded, 0 failed
+`tests/ui/request-failure-disabled.goml` OK
+<= doc-ui tests done: 1 succeeded, 0 failed, 0 filtered out

--- a/tests/ui/request-failure.output
+++ b/tests/ui/request-failure.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 request-failure... 
 [ERROR] `tests/ui/request-failure.goml` around line 2: request failed: [GET file://$CURRENT_DIR/tests/html_files/non-existent.css]: net::ERR_FILE_NOT_FOUND
-request-failure: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/request-failure.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/screenshot-info.output
+++ b/tests/ui/screenshot-info.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 screenshot-info... 
 [INFO] `tests/ui/screenshot-info.goml` line 4: Generating screenshot for CSS selector `#js-call-attr` into `tests/ui/tadam.png`
-screenshot-info: OK
-<= doc-ui tests done: 1 succeeded, 0 failed
+`tests/ui/screenshot-info.goml` OK
+<= doc-ui tests done: 1 succeeded, 0 failed, 0 filtered out

--- a/tests/ui/screenshot-on-failure.output
+++ b/tests/ui/screenshot-on-failure.output
@@ -1,6 +1,6 @@
 => Starting doc-ui tests...
 screenshot-on-failure... 
 [ERROR] `tests/ui/screenshot-on-failure.goml` line 4: The following errors happened (for selector `.content`): [Expected attribute `nb-value` to not exist, found: `12`]: for command `assert-attribute: (".content", {"nb-value": null})`
-screenshot-on-failure: FAILED
-[INFO] screenshot-on-failure-failure: Generating screenshot into `tests/ui/screenshot-on-failure-failure.png`
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/screenshot-on-failure.goml` FAILED
+[INFO] `screenshot-on-failure-failure` Generating screenshot into `tests/ui/screenshot-on-failure-failure.png`
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/scrolls.output
+++ b/tests/ui/scrolls.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 scrolls... 
 [ERROR] `tests/ui/scrolls.goml` line 22: `#does-not-exist` not found: for command `scroll-element-to: (".absolute", "#does-not-exist")`
-scrolls: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/scrolls.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/size.output
+++ b/tests/ui/size.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 size... 
 [ERROR] `tests/ui/size.goml` line 11: expected only positive numbers, found `-10` (first element of the tuple) (from command `set-window-size: (-10, 0.2)`)
-size: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/size.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/stop-at-fatal.output
+++ b/tests/ui/stop-at-fatal.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 stop-at-fatal... 
 [ERROR] `tests/ui/stop-at-fatal.goml` line 4: `#something` not found: for command `click: "#something"`
-stop-at-fatal: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/stop-at-fatal.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/store.output
+++ b/tests/ui/store.output
@@ -5,5 +5,5 @@ store...
 [ERROR] `tests/ui/store.goml` line 24: The following errors happened: [`24` contains `2` (for CONTAINS check); `24` starts with `2` (for STARTS_WITH check)]: for command `assert-variable-false: (height, "2", [STARTS_WITH, CONTAINS])`
 [ERROR] `tests/ui/store.goml` line 26: The following errors happened: [`24` contains `4` (for CONTAINS check); `24` ends with `4` (for ENDS_WITH check)]: for command `assert-variable-false: (height, "4", [CONTAINS, ENDS_WITH])`
 [ERROR] `tests/ui/store.goml` line 43: The following errors happened: ["No attribute named `data-whatever`"]: for command `store-attribute: ("header", {"data-whatever": attr})`
-store: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/store.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/store2.output
+++ b/tests/ui/store2.output
@@ -6,5 +6,5 @@ store2...
 [ERROR] `tests/ui/store2.goml` line 22: The following errors happened: [`Other page` isn't equal to `Other`]: for command `assert-variable: (document_v, "Other")`
 [ERROR] `tests/ui/store2.goml` line 25: The following errors happened: [`0` isn't equal to `Other`]: for command `assert-variable: (window_v, "Other")`
 [ERROR] `tests/ui/store2.goml` line 66: Condition `|x| == 0 && |y| == 98` (`0 == 0 && 102 == 98`) was evaluated as false: for command `assert: |x| == 0 && |y| == 98`
-store2: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/store2.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/text.output
+++ b/tests/ui/text.output
@@ -1,4 +1,4 @@
 => Starting doc-ui tests...
 text... 
-text: OK
-<= doc-ui tests done: 1 succeeded, 0 failed
+`tests/ui/text.goml` OK
+<= doc-ui tests done: 1 succeeded, 0 failed, 0 filtered out

--- a/tests/ui/unicode-text.output
+++ b/tests/ui/unicode-text.output
@@ -1,4 +1,4 @@
 => Starting doc-ui tests...
 unicode-text... 
-unicode-text: OK
-<= doc-ui tests done: 1 succeeded, 0 failed
+`tests/ui/unicode-text.goml` OK
+<= doc-ui tests done: 1 succeeded, 0 failed, 0 filtered out

--- a/tests/ui/wait-for-attribute-2.output
+++ b/tests/ui/wait-for-attribute-2.output
@@ -2,5 +2,5 @@
 wait-for-attribute-2... 
 [WARNING] `tests/ui/wait-for-attribute-2.goml` line 6: Special checks (STARTS_WITH) will be ignored for `null`
 [ERROR] `tests/ui/wait-for-attribute-2.goml` line 13: Error: The CSS selector "#i-dont-exist" was not found: for command `wait-for-attribute: ("#i-dont-exist", {"data-hoho": "heh"}, ALL)`
-wait-for-attribute-2: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-attribute-2.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-attribute-all.output
+++ b/tests/ui/wait-for-attribute-all.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-attribute-all... 
 [ERROR] `tests/ui/wait-for-attribute-all.goml` line 4: Error: The following attributes still don't match: [Attribute named `data-hoho` doesn't exist] (on the element number 0): for command `wait-for-attribute: ("button", {"data-hoho": "heh"}, ALL)`
-wait-for-attribute-all: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-attribute-all.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-attribute-false.output
+++ b/tests/ui/wait-for-attribute-false.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-attribute-false... 
 [ERROR] `tests/ui/wait-for-attribute-false.goml` line 14: Error: All attributes still match: for command `wait-for-attribute-false: ("#created-one", {"data-a": "x"})`
-wait-for-attribute-false: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-attribute-false.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-attribute.output
+++ b/tests/ui/wait-for-attribute.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-attribute... 
 [ERROR] `tests/ui/wait-for-attribute.goml` line 13: Error: The following attributes still don't match: [expected `c` for attribute `data-a`, found `b`]: for command `wait-for-attribute: ("#js-call-attr", {"data-a": "c"})`
-wait-for-attribute: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-attribute.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-count-false.output
+++ b/tests/ui/wait-for-count-false.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-count-false... 
 [ERROR] `tests/ui/wait-for-count-false.goml` line 9: Error: There are still 2 instances of ".random-class": for command `wait-for-count-false: (".random-class", 2)`
-wait-for-count-false: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-count-false.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-count.output
+++ b/tests/ui/wait-for-count.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-count... 
 [ERROR] `tests/ui/wait-for-count.goml` line 9: Error: Still didn't find 3 instances of ".random-class" (found 2): for command `wait-for-count: (".random-class", 3)`
-wait-for-count: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-count.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-css-2.output
+++ b/tests/ui/wait-for-css-2.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-css-2... 
 [ERROR] `tests/ui/wait-for-css-2.goml` line 9: Error: The CSS selector "#i-dont-exist" was not found: for command `wait-for-css: ("#i-dont-exist", {"color": "blue"}, ALL)`
-wait-for-css-2: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-css-2.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-css-false.output
+++ b/tests/ui/wait-for-css-false.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-css-false... 
 [ERROR] `tests/ui/wait-for-css-false.goml` line 18: Error: All CSS properties still match: for command `wait-for-css-false: ("#js-call", {"margin-top": "12px"})`
-wait-for-css-false: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-css-false.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-css.output
+++ b/tests/ui/wait-for-css.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-css... 
 [ERROR] `tests/ui/wait-for-css.goml` line 18: Error: The following CSS properties still don't match: [expected `13px` for key `margin-top`, found `12px`]: for command `wait-for-css: ("#js-call", {"margin-top": "13px"})`
-wait-for-css: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-css.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-document-property-false.output
+++ b/tests/ui/wait-for-document-property-false.output
@@ -2,5 +2,5 @@
 wait-for-document-property-false... 
 [ERROR] `tests/ui/wait-for-document-property-false.goml` line 14: Error: The document properties still all match: for command `wait-for-document-property-false: {"windowProp": "hello1"}`
 [ERROR] `tests/ui/wait-for-document-property-false.goml` line 17: Error: The document properties still all match: for command `wait-for-document-property-false: {"windowProp": "hello1"}`
-wait-for-document-property-false: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-document-property-false.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-document-property.output
+++ b/tests/ui/wait-for-document-property.output
@@ -3,5 +3,5 @@ wait-for-document-property...
 [WARNING] `tests/ui/wait-for-document-property.goml` line 12: Special checks (ENDS_WITH) will be ignored for `null`
 [ERROR] `tests/ui/wait-for-document-property.goml` line 14: Error: The following document properties still don't match: [expected `tadam` for document property `windowProp`, found `hello1`]: for command `wait-for-document-property: {"windowProp": "tadam"}`
 [ERROR] `tests/ui/wait-for-document-property.goml` line 17: The following errors happened: [expected `tadam` for document property `windowProp`, found `hello1`]: for command `assert-document-property: {"windowProp": "tadam"}`
-wait-for-document-property: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-document-property.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-false.output
+++ b/tests/ui/wait-for-false.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-false... 
 [ERROR] `tests/ui/wait-for-false.goml` line 10: Error: The CSS selector "#created-one" was not found: for command `wait-for: "#created-one"`
-wait-for-false: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-false.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-local-storage-false.output
+++ b/tests/ui/wait-for-local-storage-false.output
@@ -2,5 +2,5 @@
 wait-for-local-storage-false... 
 [ERROR] `tests/ui/wait-for-local-storage-false.goml` line 9: Error: All local storage entries still match: for command `wait-for-local-storage-false: {"something3": "hello hi"}`
 [ERROR] `tests/ui/wait-for-local-storage-false.goml` line 12: The following errors happened: [localStorage item "something3" (of value "tadam") != "hello hi"]: for command `assert-local-storage: {"something3": "tadam"}`
-wait-for-local-storage-false: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-local-storage-false.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-local-storage.output
+++ b/tests/ui/wait-for-local-storage.output
@@ -2,5 +2,5 @@
 wait-for-local-storage... 
 [ERROR] `tests/ui/wait-for-local-storage.goml` line 10: Error: The following local storage entries still don't match: [localStorage item "something2" (of value "tadam") != "hello hi"]: for command `wait-for-local-storage: {"something2": "tadam"}`
 [ERROR] `tests/ui/wait-for-local-storage.goml` line 13: The following errors happened: [localStorage item "something2" (of value "tadam") != "hello hi"]: for command `assert-local-storage: {"something2": "tadam"}`
-wait-for-local-storage: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-local-storage.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-position-false.output
+++ b/tests/ui/wait-for-position-false.output
@@ -2,5 +2,5 @@
 wait-for-position-false... 
 [ERROR] `tests/ui/wait-for-position-false.goml` line 15: Error: All checks still succeed: for command `wait-for-position-false: ("#js-change-pos", {"y": 91})`
 [ERROR] `tests/ui/wait-for-position-false.goml` line 18: The following errors happened: [different Y values: 91 (or 91) != 16]: for command `assert-position: ("#js-change-pos", {"y": 16})`
-wait-for-position-false: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-position-false.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-position.output
+++ b/tests/ui/wait-for-position.output
@@ -4,5 +4,5 @@ wait-for-position...
 [ERROR] `tests/ui/wait-for-position.goml` line 10: Error: The following checks still fail: [different X values: 588.34375 (or 588) != 546]: for command `wait-for-position: ("#js-change-pos", {"x": 546})`
 [ERROR] `tests/ui/wait-for-position.goml` line 17: Error: The following checks still fail: [different Y values: 91 (or 91) != 16]: for command `wait-for-position: ("#js-change-pos", {"y": 16})`
 [ERROR] `tests/ui/wait-for-position.goml` line 20: The following errors happened: [different Y values: 91 (or 91) != 16]: for command `assert-position: ("#js-change-pos", {"y": 16})`
-wait-for-position: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-position.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-property-2.output
+++ b/tests/ui/wait-for-property-2.output
@@ -2,5 +2,5 @@
 wait-for-property-2... 
 [WARNING] `tests/ui/wait-for-property-2.goml` line 6: Special checks (STARTS_WITH) will be ignored for `null`
 [ERROR] `tests/ui/wait-for-property-2.goml` line 12: Error: The CSS selector "#i-dont-exist" was not found: for command `wait-for-property: ("#i-dont-exist", {"data-huh": "heh"}, ALL)`
-wait-for-property-2: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-property-2.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-property-3.output
+++ b/tests/ui/wait-for-property-3.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-property-3... 
 [ERROR] `tests/ui/wait-for-property-3.goml` line 6: Error: The following properties still don't match: [expected `a` for property `offsetLeft`, found `0`]: for command `wait-for-property: ("html", {"offsetLeft": "a"})`
-wait-for-property-3: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-property-3.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-property-false.output
+++ b/tests/ui/wait-for-property-false.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-property-false... 
 [ERROR] `tests/ui/wait-for-property-false.goml` line 19: Error: All properties still match: for command `wait-for-property-false: ("#js-wait-prop", {"hehe": "hoho"})`
-wait-for-property-false: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-property-false.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-property.output
+++ b/tests/ui/wait-for-property.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-property... 
 [ERROR] `tests/ui/wait-for-property.goml` line 20: Error: The following properties still don't match: [Property `"data-a"` doesn't exist]: for command `wait-for-property: ("#js-wait-prop", {"data-a": "c"})`
-wait-for-property: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-property.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-size-false.output
+++ b/tests/ui/wait-for-size-false.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-size-false... 
 [ERROR] `tests/ui/wait-for-size-false.goml` line 15: The following errors happened: [expected a height of `26`, found `23`]: for command `assert-size: ("#js-change-size", {"height": 26, "width": 33})`
-wait-for-size-false: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-size-false.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-size.output
+++ b/tests/ui/wait-for-size.output
@@ -3,5 +3,5 @@ wait-for-size...
 [ERROR] `tests/ui/wait-for-size.goml` line 14: Error: The following checks still fail: [expected a width of `33`, found `36`]: for command `wait-for-size: ("#js-change-size", {"height": 26, "width": 33})`
 [ERROR] `tests/ui/wait-for-size.goml` line 17: The following errors happened: [expected a width of `33`, found `36`]: for command `assert-size: ("#js-change-size", {"height": 26, "width": 33})`
 [ERROR] `tests/ui/wait-for-size.goml` line 20: Error: The following checks still fail: [expected a width of `33`, found `36`] (on the element number 0): for command `wait-for-size: ("#js-change-size", {"height": 26, "width": 33}, ALL)`
-wait-for-size: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-size.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-text-2.output
+++ b/tests/ui/wait-for-text-2.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-text-2... 
 [ERROR] `tests/ui/wait-for-text-2.goml` line 10: Error: The CSS selector "#i-dont-exist" was not found: for command `wait-for-text: ("#i-dont-exist", "oho")`
-wait-for-text-2: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-text-2.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-text-all.output
+++ b/tests/ui/wait-for-text-all.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-text-all... 
 [ERROR] `tests/ui/wait-for-text-all.goml` line 5: Error: The following checks still fail: [`hey` isn't equal to `heafd`] (on the element number 0): for command `wait-for-text: ("button", "heafd", [ALL])`
-wait-for-text-all: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-text-all.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-text-false.output
+++ b/tests/ui/wait-for-text-false.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-text-false... 
 [ERROR] `tests/ui/wait-for-text-false.goml` line 12: Error: All checks still pass: for command `wait-for-text-false: ("#js-call-attr", "hello")`
-wait-for-text-false: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-text-false.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-text.output
+++ b/tests/ui/wait-for-text.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-text... 
 [ERROR] `tests/ui/wait-for-text.goml` line 12: Error: The following checks still fail: [`hello` isn't equal to `hello bis`]: for command `wait-for-text: ("#js-call-attr", "hello bis")`
-wait-for-text: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-text.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-window-property-false.output
+++ b/tests/ui/wait-for-window-property-false.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for-window-property-false... 
 [ERROR] `tests/ui/wait-for-window-property-false.goml` line 16: The following errors happened: [expected `tadam` for window property `windowProp`, found `hello1`]: for command `assert-window-property: {"windowProp": "tadam"}`
-wait-for-window-property-false: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-window-property-false.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for-window-property.output
+++ b/tests/ui/wait-for-window-property.output
@@ -3,5 +3,5 @@ wait-for-window-property...
 [WARNING] `tests/ui/wait-for-window-property.goml` line 12: Special checks (ENDS_WITH) will be ignored for `null`
 [ERROR] `tests/ui/wait-for-window-property.goml` line 14: Error: The following window properties still don't match: [expected `tadam` for window property `windowProp`, found `hello1`]: for command `wait-for-window-property: {"windowProp": "tadam"}`
 [ERROR] `tests/ui/wait-for-window-property.goml` line 17: The following errors happened: [expected `tadam` for window property `windowProp`, found `hello1`]: for command `assert-window-property: {"windowProp": "tadam"}`
-wait-for-window-property: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for-window-property.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/wait-for.output
+++ b/tests/ui/wait-for.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 wait-for... 
 [ERROR] `tests/ui/wait-for.goml` line 16: Error: The CSS selector "#created-one" still exists: for command `wait-for-false: "#created-one"`
-wait-for: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/wait-for.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/within-iframe-2.output
+++ b/tests/ui/within-iframe-2.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 within-iframe-2... 
 [ERROR] `tests/ui/within-iframe-2.goml` line 4: selector `#the-input` is not an `<iframe>` but a `<input>`: for command `within-iframe: ("#the-input", block {})`
-within-iframe-2: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/within-iframe-2.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/within-iframe.output
+++ b/tests/ui/within-iframe.output
@@ -1,5 +1,5 @@
 => Starting doc-ui tests...
 within-iframe... 
 [ERROR] `tests/ui/within-iframe.goml` line 41: `#ifra` not found: for command `within-iframe: ("#ifra", block {})`
-within-iframe: FAILED
-<= doc-ui tests done: 0 succeeded, 1 failed
+`tests/ui/within-iframe.goml` FAILED
+<= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/write.output
+++ b/tests/ui/write.output
@@ -1,4 +1,4 @@
 => Starting doc-ui tests...
 write... 
-write: OK
-<= doc-ui tests done: 1 succeeded, 0 failed
+`tests/ui/write.goml` OK
+<= doc-ui tests done: 1 succeeded, 0 failed, 0 filtered out

--- a/tools/exported_items.js
+++ b/tools/exported_items.js
@@ -176,7 +176,7 @@ async function checkRunTests(x, func) {
         [`=> Starting doc-ui tests (on ${nbThreads} threads)...
 basic... OK
 
-<= doc-ui tests done: 1 succeeded, 0 failed
+<= doc-ui tests done: 1 succeeded, 0 failed, 0 filtered out
 
 `, 0]);
 
@@ -276,7 +276,7 @@ async function checkOptions(x) {
     await x.assertTry(() => options.parseArguments(['--browser']), [],
         'Missing browser name after `--browser` option');
     await x.assertTry(() => options.parseArguments(['--browser', 'test']), [],
-        '`--browser` option only accepts "chrome" or "firefox" as values, found `test`');
+        '`--browser` option only accepts `chrome` or `firefox` as value, found `test`');
     await x.assertTry(() => options.parseArguments(['--browser', 'firefox']), [], true);
     await x.assert(options.browser, 'firefox');
     await x.assertTry(() => options.parseArguments(['--browser', 'chrome']), [], true);
@@ -328,7 +328,7 @@ async function checkOptions(x) {
     await x.assertTry(() => options.parseArguments(['--browser']), [],
         'Missing browser name after `--browser` option');
     await x.assertTry(() => options.parseArguments(['--browser', 'opera']), [],
-        '`--browser` option only accepts "chrome" or "firefox" as values, found `opera`');
+        '`--browser` option only accepts `chrome` or `firefox` as value, found `opera`');
     await x.assertTry(() => options.parseArguments(['--browser', 'firefox']), [], true);
     await x.assert(options.browser, 'firefox');
     await x.assertTry(() => options.parseArguments(['--browser', 'chrome  ']), [], true);

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -113,6 +113,24 @@ class Assert {
         this.extraArgs = [];
     }
 
+    assertOrBlessIntoFile(value, filePath) {
+        let fileContent = '';
+        try {
+            fileContent = fs.readFileSync(filePath, 'utf8');
+        } catch (exc) {
+            if (this.blessEnabled) {
+                this._addTest();
+                fs.writeFileSync(filePath, value);
+            } else {
+                this.addError(`Failed to read file \`${filePath}\`: ${exc}`);
+            }
+            return;
+        }
+        this.assertOrBless(value, fileContent, () => {
+            fs.writeFileSync(filePath, value);
+        }, undefined, undefined, false);
+    }
+
     assertOrBless(value1, value2, errCallback, pos, extraInfo, toJson = true, out = undefined) {
         let callback = undefined;
         if (this.blessEnabled) {


### PR DESCRIPTION
Fixes #606.

It allows to have more "compact" output like:

```
=> Starting doc-ui tests (on 16 threads)...

FFFF                                               (4/4)

======== tests/ui/assert-clipboard-2.goml ========

[ERROR] `tests/ui/assert-clipboard-2.goml` line 6: Error: The following checks still fail: [`hello` isn't equal to `hell`]: for command `wait-for-clipboard: "hell"`

======== tests/ui/assert-clipboard.goml ========

[ERROR] `tests/ui/assert-clipboard.goml` line 21: Error: All checks still succeed: for command `wait-for-clipboard-false: "hello"`

======== tests/ui/assert-css-color.goml ========

[ERROR] `tests/ui/assert-css-color.goml` line 8: `show-text: true` needs to be used before checking for `color` (otherwise the browser doesn't compute it)

======== tests/ui/assert-css.goml ========

[ERROR] `tests/ui/assert-css.goml` line 4: The following errors happened (for selector `.content>.left>p`): [expected `white` for key `color`, found `whitesmoke`]: for command `assert-css: (".content>.left>p", {"color": "white"})`
[ERROR] `tests/ui/assert-css.goml` line 6: The following errors happened (for selector `.content>.right>p`): [expected `white` for key `color`, found `rgb(244, 245, 245)`]: for command `assert-css: (".content>.right>p", {"color": "white"})`


<= doc-ui tests done: 0 succeeded, 4 failed, 81 filtered out
```