### PR TITLE
Update puppeteer to 25.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-kacst \
     fonts-freefont-ttf \
     libxss1 \
-    libxtst6
+    libxtst6 \
+    unzip
 
 RUN curl -sL https://deb.nodesource.com/setup_24.x | sudo -E bash - \
     && apt install -y nodejs

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "css-unit-converter": "^1.1.2",
                 "pngjs": "^3.4.0",
-                "puppeteer": "^24.31.0",
+                "puppeteer": "^25.1.0",
                 "readline-sync": "^1.4.10"
             },
             "bin": {
@@ -50,6 +50,7 @@
             "version": "7.22.13",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
             "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+            "dev": true,
             "dependencies": {
                 "@babel/highlight": "^7.22.13",
                 "chalk": "^2.4.2"
@@ -257,6 +258,7 @@
             "version": "7.22.20",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
             "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -288,6 +290,7 @@
             "version": "7.22.20",
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
             "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+            "dev": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.22.20",
                 "chalk": "^2.4.2",
@@ -595,62 +598,27 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "2.10.13",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.13.tgz",
-            "integrity": "sha512-a9Ruw3j3qlnB5a/zHRTkruppynxqaeE4H9WNj5eYGRWqw0ZauZ23f4W2ARf3hghF5doozyD+CRtt7XSYuYRI/Q==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.4.tgz",
+            "integrity": "sha512-HGM8iAmGTf+Y7t0373szVbTmt3d7vPkYL/1bpOkOFO0YUYLgSeuYBCzESklogNPvOBnZ/MRD5f07OkpqH1trtA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "debug": "^4.4.3",
-                "extract-zip": "^2.0.1",
-                "progress": "^2.0.3",
-                "proxy-agent": "^6.5.0",
-                "semver": "^7.7.3",
-                "tar-fs": "^3.1.1",
+                "modern-tar": "^0.7.6",
                 "yargs": "^17.7.2"
             },
             "bin": {
-                "browsers": "lib/cjs/main-cli.js"
+                "browsers": "lib/main-cli.js"
             },
             "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@puppeteer/browsers/node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
+                "node": ">=22.12.0"
             },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@tootallnate/quickjs-emscripten": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-            "license": "MIT"
-        },
-        "node_modules/@types/node": {
-            "version": "24.10.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
-            "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "undici-types": "~7.16.0"
-            }
-        },
-        "node_modules/@types/yauzl": {
-            "version": "2.10.3",
-            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-            "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@types/node": "*"
+            "peerDependencies": {
+                "proxy-agent": ">=8.0.1"
+            },
+            "peerDependenciesMeta": {
+                "proxy-agent": {
+                    "optional": true
+                }
             }
         },
         "node_modules/acorn": {
@@ -672,15 +640,6 @@
             "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/agent-base": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/ajv": {
@@ -711,6 +670,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -722,6 +682,7 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
             "dependencies": {
                 "color-name": "1.1.3"
             }
@@ -729,144 +690,20 @@
         "node_modules/ansi-styles/node_modules/color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
         },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "node_modules/ast-types": {
-            "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/b4a": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-            "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "react-native-b4a": "*"
-            },
-            "peerDependenciesMeta": {
-                "react-native-b4a": {
-                    "optional": true
-                }
-            }
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
-        },
-        "node_modules/bare-events": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-            "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "bare-abort-controller": "*"
-            },
-            "peerDependenciesMeta": {
-                "bare-abort-controller": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/bare-fs": {
-            "version": "4.5.2",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
-            "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "bare-events": "^2.5.4",
-                "bare-path": "^3.0.0",
-                "bare-stream": "^2.6.4",
-                "bare-url": "^2.2.2",
-                "fast-fifo": "^1.3.2"
-            },
-            "engines": {
-                "bare": ">=1.16.0"
-            },
-            "peerDependencies": {
-                "bare-buffer": "*"
-            },
-            "peerDependenciesMeta": {
-                "bare-buffer": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/bare-os": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-            "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "engines": {
-                "bare": ">=1.14.0"
-            }
-        },
-        "node_modules/bare-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-            "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "bare-os": "^3.0.1"
-            }
-        },
-        "node_modules/bare-stream": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-            "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "streamx": "^2.21.0"
-            },
-            "peerDependencies": {
-                "bare-buffer": "*",
-                "bare-events": "*"
-            },
-            "peerDependenciesMeta": {
-                "bare-buffer": {
-                    "optional": true
-                },
-                "bare-events": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/bare-url": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-            "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "bare-path": "^3.0.0"
-            }
-        },
-        "node_modules/basic-ftp": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-            "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            }
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -910,19 +747,11 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
-        "node_modules/buffer-crc32": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -951,6 +780,7 @@
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -961,13 +791,16 @@
             }
         },
         "node_modules/chromium-bidi": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-11.0.0.tgz",
-            "integrity": "sha512-cM3DI+OOb89T3wO8cpPSro80Q9eKYJ7hGVXoGS3GkDPxnYSqiv+6xwpIf6XERyJ9Tdsl09hmNmY94BkgZdVekw==",
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-16.0.1.tgz",
+            "integrity": "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "mitt": "^3.0.1",
                 "zod": "^3.24.1"
+            },
+            "engines": {
+                "node": ">=20.19.0 <22.0.0 || >=22.12.0"
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
@@ -1015,31 +848,6 @@
             "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
             "dev": true
         },
-        "node_modules/cosmiconfig": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-            "dependencies": {
-                "env-paths": "^2.2.1",
-                "import-fresh": "^3.3.0",
-                "js-yaml": "^4.1.0",
-                "parse-json": "^5.2.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.9.5"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1060,19 +868,11 @@
             "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
             "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA=="
         },
-        "node_modules/data-uri-to-buffer": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -1092,24 +892,10 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
         },
-        "node_modules/degenerator": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-            "license": "MIT",
-            "dependencies": {
-                "ast-types": "^0.13.4",
-                "escodegen": "^2.1.0",
-                "esprima": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1521046",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
-            "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
+            "version": "0.0.1624250",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1624250.tgz",
+            "integrity": "sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA==",
             "license": "BSD-3-Clause"
         },
         "node_modules/doctrine": {
@@ -1136,31 +922,6 @@
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "license": "MIT"
         },
-        "node_modules/end-of-stream": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-            "license": "MIT",
-            "dependencies": {
-                "once": "^1.4.0"
-            }
-        },
-        "node_modules/env-paths": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/error-ex": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dependencies": {
-                "is-arrayish": "^0.2.1"
-            }
-        },
         "node_modules/escalade": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -1173,29 +934,9 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
-            }
-        },
-        "node_modules/escodegen": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "esprima": "^4.0.1",
-                "estraverse": "^5.2.0",
-                "esutils": "^2.0.2"
-            },
-            "bin": {
-                "escodegen": "bin/escodegen.js",
-                "esgenerate": "bin/esgenerate.js"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "optionalDependencies": {
-                "source-map": "~0.6.1"
             }
         },
         "node_modules/eslint": {
@@ -1388,19 +1129,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "license": "BSD-2-Clause",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/esquery": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
@@ -1429,6 +1157,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -1437,37 +1166,9 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/events-universal": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-            "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "bare-events": "^2.7.0"
-            }
-        },
-        "node_modules/extract-zip": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "debug": "^4.1.1",
-                "get-stream": "^5.1.0",
-                "yauzl": "^2.10.0"
-            },
-            "bin": {
-                "extract-zip": "cli.js"
-            },
-            "engines": {
-                "node": ">= 10.17.0"
-            },
-            "optionalDependencies": {
-                "@types/yauzl": "^2.9.1"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -1475,12 +1176,6 @@
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
-        },
-        "node_modules/fast-fifo": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-            "license": "MIT"
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -1501,15 +1196,6 @@
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/fd-slicer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-            "license": "MIT",
-            "dependencies": {
-                "pend": "~1.2.0"
             }
         },
         "node_modules/file-entry-cache": {
@@ -1584,35 +1270,6 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
-        "node_modules/get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-            "license": "MIT",
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/get-uri": {
-            "version": "6.0.5",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-            "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-            "license": "MIT",
-            "dependencies": {
-                "basic-ftp": "^5.0.2",
-                "data-uri-to-buffer": "^6.0.2",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -1664,34 +1321,9 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/https-proxy-agent": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/ignore": {
@@ -1707,6 +1339,7 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "dev": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -1742,20 +1375,6 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
-        },
-        "node_modules/ip-address": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 12"
-            }
-        },
-        "node_modules/is-arrayish": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
@@ -1805,12 +1424,14 @@
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
         },
         "node_modules/js-yaml": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
             "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -1836,11 +1457,6 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true
-        },
-        "node_modules/json-parse-even-better-errors": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -1888,10 +1504,17 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/lines-and-columns": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+        "node_modules/lilconfig": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+            "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antonk52"
+            }
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
@@ -1941,10 +1564,20 @@
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
             "license": "MIT"
         },
+        "node_modules/modern-tar": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
+            "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/natural-compare": {
@@ -1952,15 +1585,6 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
-        },
-        "node_modules/netmask": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4.0"
-            }
         },
         "node_modules/node-releases": {
             "version": "2.0.13",
@@ -1972,6 +1596,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -2023,64 +1648,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/pac-proxy-agent": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-            "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-            "license": "MIT",
-            "dependencies": {
-                "@tootallnate/quickjs-emscripten": "^0.23.0",
-                "agent-base": "^7.1.2",
-                "debug": "^4.3.4",
-                "get-uri": "^6.0.1",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.6",
-                "pac-resolver": "^7.0.1",
-                "socks-proxy-agent": "^8.0.5"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/pac-resolver": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-            "license": "MIT",
-            "dependencies": {
-                "degenerator": "^5.0.0",
-                "netmask": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/parse-json": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-            "dependencies": {
-                "@babel/code-frame": "^7.0.0",
-                "error-ex": "^1.3.1",
-                "json-parse-even-better-errors": "^2.3.0",
-                "lines-and-columns": "^1.1.6"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/path-exists": {
@@ -2110,12 +1687,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/pend": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-            "license": "MIT"
-        },
         "node_modules/picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -2139,59 +1710,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/progress": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/proxy-agent": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-            "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "^4.3.4",
-                "http-proxy-agent": "^7.0.1",
-                "https-proxy-agent": "^7.0.6",
-                "lru-cache": "^7.14.1",
-                "pac-proxy-agent": "^7.1.0",
-                "proxy-from-env": "^1.1.0",
-                "socks-proxy-agent": "^8.0.5"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/proxy-agent/node_modules/lru-cache": {
-            "version": "7.18.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
-        },
-        "node_modules/pump": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-            "license": "MIT",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
         "node_modules/punycode": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -2202,42 +1720,41 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "24.31.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.31.0.tgz",
-            "integrity": "sha512-q8y5yLxLD8xdZdzNWqdOL43NbfvUOp60SYhaLZQwHC9CdKldxQKXOyJAciOr7oUJfyAH/KgB2wKvqT2sFKoVXA==",
+            "version": "25.1.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.1.0.tgz",
+            "integrity": "sha512-7L6/0JM7XStK99lIL4xQySyNEXNfII6pk0BxkI5kKBTOhR7AsoQiv067YTsE/rIXxQiq9ajlO4WcqBjS/FWK1A==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "2.10.13",
-                "chromium-bidi": "11.0.0",
-                "cosmiconfig": "^9.0.0",
-                "devtools-protocol": "0.0.1521046",
-                "puppeteer-core": "24.31.0",
-                "typed-query-selector": "^2.12.0"
+                "@puppeteer/browsers": "3.0.4",
+                "chromium-bidi": "16.0.1",
+                "devtools-protocol": "0.0.1624250",
+                "lilconfig": "^3.1.3",
+                "puppeteer-core": "25.1.0",
+                "typed-query-selector": "^2.12.2"
             },
             "bin": {
-                "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+                "puppeteer": "lib/puppeteer/node/cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22.12.0"
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "24.31.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.31.0.tgz",
-            "integrity": "sha512-pnAohhSZipWQoFpXuGV7xCZfaGhqcBR9C4pVrU0QSrcMi7tQMH9J9lDBqBvyMAHQqe8HCARuREqFuVKRQOgTvg==",
+            "version": "25.1.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.1.0.tgz",
+            "integrity": "sha512-jKzy5y4WG6uNuFbTWgW1D7mqoT9o0nllc/6a1DGF775T1mPmgw3scdFEtEq67yVFikavQmbYq6NLfbTfxHSlqQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "2.10.13",
-                "chromium-bidi": "11.0.0",
-                "debug": "^4.4.3",
-                "devtools-protocol": "0.0.1521046",
-                "typed-query-selector": "^2.12.0",
-                "webdriver-bidi-protocol": "0.3.9",
-                "ws": "^8.18.3"
+                "@puppeteer/browsers": "3.0.4",
+                "chromium-bidi": "16.0.1",
+                "devtools-protocol": "0.0.1624250",
+                "typed-query-selector": "^2.12.2",
+                "webdriver-bidi-protocol": "0.4.2",
+                "ws": "^8.21.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22.12.0"
             }
         },
         "node_modules/queue-microtask": {
@@ -2281,6 +1798,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -2363,65 +1881,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/smart-buffer": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/socks": {
-            "version": "2.8.7",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-            "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-            "license": "MIT",
-            "dependencies": {
-                "ip-address": "^10.0.1",
-                "smart-buffer": "^4.2.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/socks-proxy-agent": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "^4.3.4",
-                "socks": "^2.8.3"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/streamx": {
-            "version": "2.23.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-            "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
-            "license": "MIT",
-            "dependencies": {
-                "events-universal": "^1.0.0",
-                "fast-fifo": "^1.3.2",
-                "text-decoder": "^1.1.0"
-            }
-        },
         "node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -2463,45 +1922,12 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/tar-fs": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-            "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
-            "license": "MIT",
-            "dependencies": {
-                "pump": "^3.0.0",
-                "tar-stream": "^3.1.5"
-            },
-            "optionalDependencies": {
-                "bare-fs": "^4.0.1",
-                "bare-path": "^3.0.0"
-            }
-        },
-        "node_modules/tar-stream": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-            "license": "MIT",
-            "dependencies": {
-                "b4a": "^1.6.4",
-                "fast-fifo": "^1.2.0",
-                "streamx": "^2.15.0"
-            }
-        },
-        "node_modules/text-decoder": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-            "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "b4a": "^1.6.4"
             }
         },
         "node_modules/text-table": {
@@ -2518,12 +1944,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -2550,17 +1970,10 @@
             }
         },
         "node_modules/typed-query-selector": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-            "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+            "version": "2.12.2",
+            "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+            "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
             "license": "MIT"
-        },
-        "node_modules/undici-types": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/update-browserslist-db": {
             "version": "1.0.12",
@@ -2602,9 +2015,9 @@
             }
         },
         "node_modules/webdriver-bidi-protocol": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.9.tgz",
-            "integrity": "sha512-uIYvlRQ0PwtZR1EzHlTMol1G0lAlmOe6wPykF9a77AK3bkpvZHzIVxRE2ThOx5vjy2zISe0zhwf5rzuUfbo1PQ==",
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+            "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
             "license": "Apache-2.0"
         },
         "node_modules/which": {
@@ -2657,7 +2070,8 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "node_modules/ws": {
             "version": "8.21.0",
@@ -2720,16 +2134,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/yauzl": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-            "license": "MIT",
-            "dependencies": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.1.0"
             }
         },
         "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "css-unit-converter": "^1.1.2",
         "pngjs": "^3.4.0",
-        "puppeteer": "^24.31.0",
+        "puppeteer": "^25.1.0",
         "readline-sync": "^1.4.10"
     },
     "devDependencies": {

--- a/tests/full-check/attribute.goml
+++ b/tests/full-check/attribute.goml
@@ -7,9 +7,9 @@ assert-attribute: ("#yet-another-id", {"test": "lol"})
 expect-failure: true
 set-attribute: ("#yet-another-id", {"\"a": "'b", "c": "d"})
 assert-attribute: ("#yet-another-id", {"\a": "'b", "c": "d", "\"e": "'2"})
+expect-failure: false
 set-attribute: ("#yet-another-id", {"\"e": "'2"})
 assert-attribute: ("#yet-another-id", {"\"e": "'2"})
-expect-failure: false
 set-attribute: ("#yet-another-id", {"e": "'2"})
 assert-attribute: ("#yet-another-id", {"e": "'2"})
 set-attribute: ("#yet-another-id", {"e": "2"})


### PR DESCRIPTION
This updates puppeteer to 25.1.0. This fixes a problem where puppeteer fails to run with node 24.16.0. More information can be found at https://github.com/actions/runner-images/issues/14173.

Changelog: https://pptr.dev/CHANGELOG#2510-2026-05-26