### PR TITLE
Don't call overridePermissions if we don't need to

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -431,6 +431,7 @@ function parseTest(testName, testPath, logs, options, content) {
 const EXPORTS = {
     'ParserWithContext': ParserWithContext,
     'COLOR_CHECK_ERROR': consts.COLOR_CHECK_ERROR,
+    'CLIPBOARD_PERMISSION_ERROR': consts.CLIPBOARD_PERMISSION_ERROR,
     'ORDERS': ORDERS,
     'parseTest': parseTest,
 };

--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -1,5 +1,7 @@
 // Utility functions used by the command parsing functions.
 
+const consts = require('../consts.js');
+
 function codeSelector(selector) {
     const selectorS = selector.isXPath ? `::-p-xpath(${selector.value})` : selector.value;
     return `"${selectorS}"`;
@@ -423,6 +425,9 @@ await page.evaluate(() => {
 });
 const clipboardClickElem = await page.waitForSelector("#${id}", {timeout: 1000});`,
         `\
+if (arg.permissions.indexOf("clipboard-read") < 0) {
+    throw '${consts.CLIPBOARD_PERMISSION_ERROR}';
+}
 await clipboardClickElem.click();
 const ${varName} = await page.evaluate(() => document.getElementById("${id}").clipboardContent);`,
         async page => {

--- a/src/consts.js
+++ b/src/consts.js
@@ -22,4 +22,6 @@ module.exports = {
     ],
     'COLOR_CHECK_ERROR': '`show-text: true` needs to be used before checking for `color` ' +
         '(otherwise the browser doesn\'t compute it)',
+    'CLIPBOARD_PERMISSION_ERROR': '`permissions: ["clipboard-read"]` is needed before the ' +
+        'clipboard can be read',
 };

--- a/src/puppeteer-wrapper.js
+++ b/src/puppeteer-wrapper.js
@@ -116,8 +116,7 @@ class PuppeteerWrapper {
         }
         let value = this.permissions.get(url);
         if (value === undefined) {
-            // FIXME: should we really set this permission by default?
-            this.permissions.set(url, new Set(['clipboard-read']));
+            this.permissions.set(url, new Set());
             // this.permissions.set(url, new Map());
             value = this.permissions.get(url);
         }
@@ -149,8 +148,12 @@ class PuppeteerWrapper {
         //         value.set(permission, nb - 1);
         //     }
         // }
-        const context = this.context === null ? this.browser.defaultBrowserContext() : this.context;
-        await context.overridePermissions(url, Array.from(value));
+        if (value.size) {
+            const context = this.context === null ?
+                this.browser.defaultBrowserContext() :
+                this.context;
+            await context.overridePermissions(url, Array.from(value));
+        }
     }
 
     async emulate(options, fileInfo, page, logs) {

--- a/tests/api-output/parseAssertClipboard/basic-1.toml
+++ b/tests/api-output/parseAssertClipboard/basic-1.toml
@@ -15,6 +15,9 @@ instructions = [
 });
 const clipboardClickElem = await page.waitForSelector(\"#created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\", {timeout: 1000});
 const value = \"a\";
+if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+    throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+}
 await clipboardClickElem.click();
 const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
 const errors = [];

--- a/tests/api-output/parseAssertClipboard/basic-2.toml
+++ b/tests/api-output/parseAssertClipboard/basic-2.toml
@@ -15,6 +15,9 @@ instructions = [
 });
 const clipboardClickElem = await page.waitForSelector(\"#created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\", {timeout: 1000});
 const value = \"a\";
+if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+    throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+}
 await clipboardClickElem.click();
 const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
 const errors = [];

--- a/tests/api-output/parseAssertClipboard/basic-3.toml
+++ b/tests/api-output/parseAssertClipboard/basic-3.toml
@@ -15,6 +15,9 @@ instructions = [
 });
 const clipboardClickElem = await page.waitForSelector(\"#created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\", {timeout: 1000});
 const value = \"a\";
+if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+    throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+}
 await clipboardClickElem.click();
 const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
 const errors = [];

--- a/tests/api-output/parseAssertClipboard/basic-4.toml
+++ b/tests/api-output/parseAssertClipboard/basic-4.toml
@@ -15,6 +15,9 @@ instructions = [
 });
 const clipboardClickElem = await page.waitForSelector(\"#created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\", {timeout: 1000});
 const value = \"a\";
+if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+    throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+}
 await clipboardClickElem.click();
 const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
 const errors = [];

--- a/tests/api-output/parseAssertClipboardFalse/basic-1.toml
+++ b/tests/api-output/parseAssertClipboardFalse/basic-1.toml
@@ -15,6 +15,9 @@ instructions = [
 });
 const clipboardClickElem = await page.waitForSelector(\"#created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\", {timeout: 1000});
 const value = \"a\";
+if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+    throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+}
 await clipboardClickElem.click();
 const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
 const errors = [];

--- a/tests/api-output/parseAssertClipboardFalse/basic-2.toml
+++ b/tests/api-output/parseAssertClipboardFalse/basic-2.toml
@@ -15,6 +15,9 @@ instructions = [
 });
 const clipboardClickElem = await page.waitForSelector(\"#created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\", {timeout: 1000});
 const value = \"a\";
+if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+    throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+}
 await clipboardClickElem.click();
 const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
 const errors = [];

--- a/tests/api-output/parseAssertClipboardFalse/basic-3.toml
+++ b/tests/api-output/parseAssertClipboardFalse/basic-3.toml
@@ -15,6 +15,9 @@ instructions = [
 });
 const clipboardClickElem = await page.waitForSelector(\"#created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\", {timeout: 1000});
 const value = \"a\";
+if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+    throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+}
 await clipboardClickElem.click();
 const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
 const errors = [];

--- a/tests/api-output/parseAssertClipboardFalse/basic-4.toml
+++ b/tests/api-output/parseAssertClipboardFalse/basic-4.toml
@@ -15,6 +15,9 @@ instructions = [
 });
 const clipboardClickElem = await page.waitForSelector(\"#created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\", {timeout: 1000});
 const value = \"a\";
+if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+    throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+}
 await clipboardClickElem.click();
 const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
 const errors = [];

--- a/tests/api-output/parseStoreClipboard/basic-1.toml
+++ b/tests/api-output/parseStoreClipboard/basic-1.toml
@@ -15,6 +15,9 @@ instructions = [
 });
 const clipboardClickElem = await page.waitForSelector(\"#created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\", {timeout: 1000});
 
+if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+    throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+}
 await clipboardClickElem.click();
 const clipData = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
 arg.setVariable(\"tmp\", clipData);""",

--- a/tests/api-output/parseWaitForClipboard/basic-1.toml
+++ b/tests/api-output/parseWaitForClipboard/basic-1.toml
@@ -19,6 +19,9 @@ const timeAdd = 50;
 let allTime = 0;
 let errors = null;
 while (true) {
+    if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+        throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+    }
     await clipboardClickElem.click();
     const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
     errors = [];

--- a/tests/api-output/parseWaitForClipboard/basic-2.toml
+++ b/tests/api-output/parseWaitForClipboard/basic-2.toml
@@ -19,6 +19,9 @@ const timeAdd = 50;
 let allTime = 0;
 let errors = null;
 while (true) {
+    if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+        throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+    }
     await clipboardClickElem.click();
     const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
     errors = [];

--- a/tests/api-output/parseWaitForClipboard/basic-3.toml
+++ b/tests/api-output/parseWaitForClipboard/basic-3.toml
@@ -19,6 +19,9 @@ const timeAdd = 50;
 let allTime = 0;
 let errors = null;
 while (true) {
+    if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+        throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+    }
     await clipboardClickElem.click();
     const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
     errors = [];

--- a/tests/api-output/parseWaitForClipboard/basic-4.toml
+++ b/tests/api-output/parseWaitForClipboard/basic-4.toml
@@ -19,6 +19,9 @@ const timeAdd = 50;
 let allTime = 0;
 let errors = null;
 while (true) {
+    if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+        throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+    }
     await clipboardClickElem.click();
     const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
     errors = [];

--- a/tests/api-output/parseWaitForClipboardFalse/basic-1.toml
+++ b/tests/api-output/parseWaitForClipboardFalse/basic-1.toml
@@ -19,6 +19,9 @@ const timeAdd = 50;
 let allTime = 0;
 let errors = null;
 while (true) {
+    if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+        throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+    }
     await clipboardClickElem.click();
     const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
     errors = [];

--- a/tests/api-output/parseWaitForClipboardFalse/basic-2.toml
+++ b/tests/api-output/parseWaitForClipboardFalse/basic-2.toml
@@ -19,6 +19,9 @@ const timeAdd = 50;
 let allTime = 0;
 let errors = null;
 while (true) {
+    if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+        throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+    }
     await clipboardClickElem.click();
     const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
     errors = [];

--- a/tests/api-output/parseWaitForClipboardFalse/basic-3.toml
+++ b/tests/api-output/parseWaitForClipboardFalse/basic-3.toml
@@ -19,6 +19,9 @@ const timeAdd = 50;
 let allTime = 0;
 let errors = null;
 while (true) {
+    if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+        throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+    }
     await clipboardClickElem.click();
     const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
     errors = [];

--- a/tests/api-output/parseWaitForClipboardFalse/basic-4.toml
+++ b/tests/api-output/parseWaitForClipboardFalse/basic-4.toml
@@ -19,6 +19,9 @@ const timeAdd = 50;
 let allTime = 0;
 let errors = null;
 while (true) {
+    if (arg.permissions.indexOf(\"clipboard-read\") < 0) {
+        throw '`permissions: [\"clipboard-read\"]` is needed before the clipboard can be read';
+    }
     await clipboardClickElem.click();
     const elemText = await page.evaluate(() => document.getElementById(\"created-by-browser-ui-test-to-get-clipboard-content-in-all-contexts\").clipboardContent);
     errors = [];

--- a/tests/compact-display/compact-display.output
+++ b/tests/compact-display/compact-display.output
@@ -9,7 +9,9 @@ FFFF                                               (4/4)
 
 ======== tests/ui/assert-clipboard.goml ========
 
-[ERROR] line 22: Error: All checks still succeed: for command `wait-for-clipboard-false: "hello"`
+[ERROR] line 4: `permissions: ["clipboard-read"]` is needed before the clipboard can be read: for command `assert-clipboard: "qwfpgjluy;astdhnei"`
+    at <file://$CURRENT_DIR/tests/html_files/elements.html>
+[ERROR] line 26: Error: All checks still succeed: for command `wait-for-clipboard-false: "hello"`
     at <file://$CURRENT_DIR/tests/html_files/elements.html>
 
 ======== tests/ui/assert-css-color.goml ========

--- a/tests/compact-display/compact-display.output
+++ b/tests/compact-display/compact-display.output
@@ -4,12 +4,12 @@ FFFF                                               (4/4)
 
 ======== tests/ui/assert-clipboard-2.goml ========
 
-[ERROR] line 6: Error: The following checks still fail: [`hello` isn't equal to `hell`]: for command `wait-for-clipboard: "hell"`
+[ERROR] line 7: Error: The following checks still fail: [`hello` isn't equal to `hell`]: for command `wait-for-clipboard: "hell"`
     at <file://$CURRENT_DIR/tests/html_files/elements.html>
 
 ======== tests/ui/assert-clipboard.goml ========
 
-[ERROR] line 21: Error: All checks still succeed: for command `wait-for-clipboard-false: "hello"`
+[ERROR] line 22: Error: All checks still succeed: for command `wait-for-clipboard-false: "hello"`
     at <file://$CURRENT_DIR/tests/html_files/elements.html>
 
 ======== tests/ui/assert-css-color.goml ========

--- a/tests/ui/assert-clipboard-2.goml
+++ b/tests/ui/assert-clipboard-2.goml
@@ -2,6 +2,7 @@
 
 go-to: "file://" + |CURRENT_DIR| + "/" + |DOC_PATH| + "/elements.html"
 set-timeout: 500
+permissions: ["clipboard-read"]
 
 wait-for-clipboard: "hell"
 //~^ ERROR: [`hello` isn't equal to `hell`]

--- a/tests/ui/assert-clipboard-2.output
+++ b/tests/ui/assert-clipboard-2.output
@@ -1,5 +1,5 @@
 => Running 1 doc-ui test...
 assert-clipboard-2... FAILED
-[ERROR] line 6: Error: The following checks still fail: [`hello` isn't equal to `hell`]: for command `wait-for-clipboard: "hell"`
+[ERROR] line 7: Error: The following checks still fail: [`hello` isn't equal to `hell`]: for command `wait-for-clipboard: "hell"`
     at <file://$CURRENT_DIR/tests/html_files/elements.html>
 <= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/assert-clipboard.goml
+++ b/tests/ui/assert-clipboard.goml
@@ -1,5 +1,9 @@
 go-to: "file://" + |CURRENT_DIR| + "/" + |DOC_PATH| + "/elements.html"
 set-timeout: 500
+
+assert-clipboard: "qwfpgjluy;astdhnei"
+//~^ ERROR: `permissions: ["clipboard-read"]` is needed before the clipboard can be read
+
 permissions: ["clipboard-read"]
 
 assert-clipboard: ""

--- a/tests/ui/assert-clipboard.goml
+++ b/tests/ui/assert-clipboard.goml
@@ -1,5 +1,6 @@
 go-to: "file://" + |CURRENT_DIR| + "/" + |DOC_PATH| + "/elements.html"
 set-timeout: 500
+permissions: ["clipboard-read"]
 
 assert-clipboard: ""
 assert-clipboard-false: "a"

--- a/tests/ui/assert-clipboard.output
+++ b/tests/ui/assert-clipboard.output
@@ -1,5 +1,7 @@
 => Running 1 doc-ui test...
 assert-clipboard... FAILED
-[ERROR] line 22: Error: All checks still succeed: for command `wait-for-clipboard-false: "hello"`
+[ERROR] line 4: `permissions: ["clipboard-read"]` is needed before the clipboard can be read: for command `assert-clipboard: "qwfpgjluy;astdhnei"`
+    at <file://$CURRENT_DIR/tests/html_files/elements.html>
+[ERROR] line 26: Error: All checks still succeed: for command `wait-for-clipboard-false: "hello"`
     at <file://$CURRENT_DIR/tests/html_files/elements.html>
 <= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out

--- a/tests/ui/assert-clipboard.output
+++ b/tests/ui/assert-clipboard.output
@@ -1,5 +1,5 @@
 => Running 1 doc-ui test...
 assert-clipboard... FAILED
-[ERROR] line 21: Error: All checks still succeed: for command `wait-for-clipboard-false: "hello"`
+[ERROR] line 22: Error: All checks still succeed: for command `wait-for-clipboard-false: "hello"`
     at <file://$CURRENT_DIR/tests/html_files/elements.html>
 <= doc-ui tests done: 0 succeeded, 1 failed, 0 filtered out


### PR DESCRIPTION
These permissions things don't seem to work when I'm running with plain `http://` origin, probably because all of these permissions are only allowed in secure contexts.

I'm using this feature for testing a web app, and my test passes when this patch is applied.